### PR TITLE
Eliminate superfluous Spark tarball download

### DIFF
--- a/configs/nessie-0.5-iceberg-0.11.yml
+++ b/configs/nessie-0.5-iceberg-0.11.yml
@@ -27,5 +27,3 @@ python_dependencies:
   - pandas==1.2.4
   - pyarrow==4.0.0
 
-spark:
-  tarball: https://downloads.apache.org/spark/spark-3.0.2/spark-3.0.2-bin-hadoop2.7.tgz


### PR DESCRIPTION
Since #14, the nessiedemo library can either download (and use) a separate Spark tarball
or use the one that comes with `pyspark`. The one that comes with `pyspark` is sufficient
for our notebooks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/37)
<!-- Reviewable:end -->
