### PR TITLE
Fix "Eliminate superfluous Spark tarball download (#37)"

### DIFF
--- a/configs/nessie-0.5-iceberg-0.11.yml
+++ b/configs/nessie-0.5-iceberg-0.11.yml
@@ -27,3 +27,5 @@ python_dependencies:
   - pandas==1.2.4
   - pyarrow==4.0.0
 
+spark:
+  tarball: https://downloads.apache.org/spark/spark-3.0.2/spark-3.0.2-bin-hadoop2.7.tgz


### PR DESCRIPTION
The PR #37 broke Notebooks in Colab, because a packages there are not installed
in `sysconfig.get_paths()["purelib"]` but in a directory listed via
`site.getsitepackages()`.

This also reverts commit 3d76f3147947c1dfef279e7faebee2c17c96183a for extra safety
as a fallback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/39)
<!-- Reviewable:end -->
