### PR TITLE
Try to prevent the Nessie process becoming a Zombie on Colab

### DIFF
--- a/pydemolib/tests/test_demo.py
+++ b/pydemolib/tests/test_demo.py
@@ -75,6 +75,9 @@ class TestNessieDemo:
         ds_nba2 = demo2.fetch_dataset("nba")
         assert ds_nba == ds_nba2
 
+        demo2.stop()
+        demo2.start()
+
     def test_setup_method(self: object) -> None:
         """Test the convenience nessiedemo.demo.setup_demo()."""
         demo = setup_demo("nessie-0.5-iceberg-0.11.yml")


### PR DESCRIPTION
Running the "notebook setup code cell" twice leads to an endless loop trying to kill the Nessie process, which never succeeds, because the process became a Zombie. I suspect, it's caused by the "background thread", which is probably rather useless and a simple `.close()` on the log-file's handle should do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/40)
<!-- Reviewable:end -->
