### PR TITLE
Properly shutdown Jupyter kernel when notebook tests fail

### DIFF
--- a/colab/tests/test_nessie_iceberg_demo_nba.py
+++ b/colab/tests/test_nessie_iceberg_demo_nba.py
@@ -72,7 +72,8 @@ def notebook(tmpdir_factory):
     if not os.path.exists(path):
         path = os.path.abspath(".")
     path_to_notebook = os.path.join(path, "colab/nessie-iceberg-demo-nba.ipynb")
-    with testbook(path_to_notebook, execute=True, timeout=300) as tb:
+    with testbook(path_to_notebook, timeout=300) as tb:
+        tb.execute()
         yield tb
 
 


### PR DESCRIPTION
When a notebook doesn't execute without a failure, the associated Jupyter kernel along
with its resources (-> Nessie process) are not shutdown and linger around, which leaks
resources and causes following tests to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/50)
<!-- Reviewable:end -->
