### PR TITLE
Fix Pandas output issue in Colab

### DIFF
--- a/pydemolib/requirements_dev.txt
+++ b/pydemolib/requirements_dev.txt
@@ -18,6 +18,8 @@ assertpy==1.1
 bump2version==1.0.1
 build==0.4.0
 flake8==3.9.2
+# this fixes pandas output in Google Colab
+pandas-profiling>=3.0.0
 pip==21.1.2
 pytest==6.2.4
 pytest-forked==1.3.0


### PR DESCRIPTION
Pandas output itself is shown correctly in Colab, but right before the
output there's the following issue:

```
/usr/local/lib/python3.7/dist-packages/pandas/io/formats/format.py in to_html(self, buf, encoding, classes, notebook, border)
    986         notebook : {True, False}, optional, default False
    987             Whether the generated HTML is for IPython Notebook.
--> 988         border : int
    989             A ``border=border`` attribute is included in the opening
    990             ``<table>`` tag. Default ``pd.options.display.html.border``.

AttributeError: 'NotebookFormatter' object has no attribute 'get_result'
```

Using the latest `pandas-profiling` lib seems to fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/75)
<!-- Reviewable:end -->
