### PR TITLE
Fix mypy

### DIFF
--- a/pydemolib/requirements_lint.txt
+++ b/pydemolib/requirements_lint.txt
@@ -23,3 +23,6 @@ flake8-docstrings==1.6.0
 flake8-import-order==0.18.1
 pytest-mypy==0.8.1
 safety==1.10.3
+types-PyYAML
+types-requests
+types-simplejson


### PR DESCRIPTION
This should fix
```
  nessiedemo/demo.py:33: error: Library stubs not installed for "requests" (or incompatible with Python 3.8)
  nessiedemo/demo.py:33: note: Hint: "python3 -m pip install types-requests"
  nessiedemo/demo.py:33: note: (or run "mypy --install-types" to install all missing stub packages)
  nessiedemo/demo.py:33: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
  nessiedemo/demo.py:34: error: Library stubs not installed for "yaml" (or incompatible with Python 3.8)
  nessiedemo/demo.py:34: note: Hint: "python3 -m pip install types-PyYAML"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/77)
<!-- Reviewable:end -->
