### PR TITLE
Move pandas-profiling>=3.0.0 to requirements.txt

### DIFF
--- a/pydemolib/requirements.txt
+++ b/pydemolib/requirements.txt
@@ -15,3 +15,5 @@
 #
 PyYAML>=5.4.0
 requests>=2.23.0
+# this fixes pandas output in Google Colab
+pandas-profiling>=3.0.0

--- a/pydemolib/requirements_dev.txt
+++ b/pydemolib/requirements_dev.txt
@@ -18,8 +18,6 @@ assertpy==1.1
 bump2version==1.0.1
 build==0.4.0
 flake8==3.9.2
-# this fixes pandas output in Google Colab
-pandas-profiling>=3.0.0
 pip==21.1.2
 pytest==6.2.4
 pytest-forked==1.3.0


### PR DESCRIPTION
In the previous fix I missed that a `pip install nessiedemo` doesn't
pick up the dependencies from `requirements_dev.txt` and so we're still
ending up with an outdated `pandas-profiling` version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/78)
<!-- Reviewable:end -->
