### PR TITLE
Use pandas console output instead of HTML output

### DIFF
--- a/colab/nessie-delta-demo-nba.ipynb
+++ b/colab/nessie-delta-demo-nba.ipynb
@@ -146,7 +146,7 @@
     "# The `spark` session points to the `dev` branch.\n",
     "# Unlike Iceberg, Delta does not support referencing other Nessie references (branches, tags) using the `@reference` syntax.\n",
     "\n",
-    "spark.sql(\"select * from nessie_nba_salaries\").toPandas()"
+    "print(spark.sql(\"select * from nessie_nba_salaries\").toPandas())"
    ]
   },
   {
@@ -309,7 +309,7 @@
     "allstar_games_stats_df.write.option('hadoop.nessie.ref', 'etl').format(\"delta\")\\\n",
     "    .mode(\"overwrite\").save(demo_delta_spark.table_path(\"nessie_nba_allstar_games_stats\"))\n",
     "\n",
-    "spark.sql(\"select * from nessie_nba_allstar_games_stats\").toPandas()"
+    "print(spark.sql(\"select * from nessie_nba_allstar_games_stats\").toPandas())"
    ]
   },
   {
@@ -462,7 +462,7 @@
    "source": [
     "# Switch to the `experiment` branch.\n",
     "demo_delta_spark.change_ref(\"experiment\")\n",
-    "spark.sql(\"select count(*) from nessie_nba_salaries\").toPandas()"
+    "print(spark.sql(\"select count(*) from nessie_nba_salaries\").toPandas())"
    ]
   },
   {
@@ -484,7 +484,7 @@
    "source": [
     "# Switch back to the `main` branch.\n",
     "demo_delta_spark.change_ref(\"main\")\n",
-    "spark.sql(\"select count(*) from nessie_nba_salaries\").toPandas()"
+    "print(spark.sql(\"select count(*) from nessie_nba_salaries\").toPandas())"
    ]
   },
   {

--- a/colab/nessie-iceberg-demo-nba.ipynb
+++ b/colab/nessie-iceberg-demo-nba.ipynb
@@ -144,9 +144,9 @@
     "# Notice how we view the data of the salaries table on the `dev` branch via `@dev` via the\n",
     "# `spark` session, which itself points to the `main` branch.\n",
     "# We could get the same result using the `spark_dev` session by executing\n",
-    "# spark_dev.sql(\"select * from nessie.nba.salaries\").toPandas()\n",
+    "# print(spark_dev.sql(\"select * from nessie.nba.salaries\").toPandas())\n",
     "\n",
-    "spark.sql(\"select * from nessie.nba.`salaries@dev`\").toPandas()"
+    "print(spark.sql(\"select * from nessie.nba.`salaries@dev`\").toPandas())"
    ]
   },
   {
@@ -318,7 +318,7 @@
     "allstar_games_stats_df.write.format(\"iceberg\").mode(\"overwrite\").save(\"nessie.nba.allstar_games_stats\")\n",
     "\n",
     "# notice how we view the data on the etl branch via @etl\n",
-    "spark.sql(\"select * from nessie.nba.`allstar_games_stats@etl`\").toPandas()"
+    "print(spark.sql(\"select * from nessie.nba.`allstar_games_stats@etl`\").toPandas())"
    ]
   },
   {
@@ -469,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spark.sql(\"select count(*) from nessie.nba.`salaries@experiment`\").toPandas()"
+    "print(spark.sql(\"select count(*) from nessie.nba.`salaries@experiment`\").toPandas())"
    ]
   },
   {
@@ -490,7 +490,7 @@
    },
    "outputs": [],
    "source": [
-    "spark.sql(\"select count(*) from nessie.nba.salaries\").toPandas()\n"
+    "print(spark.sql(\"select count(*) from nessie.nba.salaries\").toPandas())\n"
    ]
   }
  ],

--- a/pydemolib/requirements.txt
+++ b/pydemolib/requirements.txt
@@ -15,5 +15,3 @@
 #
 PyYAML>=5.4.0
 requests>=2.23.0
-# this fixes pandas output in Google Colab
-pandas-profiling>=3.0.0


### PR DESCRIPTION
The previous approach of installing `pandas-profiling` doesn't work for some reason (even though a manual install of that lib in the notebook was working previously), therefore the other alternative is to avoid HTML formatting the output entirely when printing the results.

Wrapping the Pandas `DataFrame` in a `print()` will pick up a different formatter and avoid the issue.

Link that verifies that it works on this branch with Colab: https://colab.research.google.com/github/nastra/nessie-demos/blob/fix-pandas-on-colab/colab/nessie-iceberg-demo-nba.ipynb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/79)
<!-- Reviewable:end -->
