### PR TITLE
Use Apache Archive URL for Spark download

### DIFF
--- a/configs/nessie-0.5-iceberg-0.11.yml
+++ b/configs/nessie-0.5-iceberg-0.11.yml
@@ -26,4 +26,4 @@ python_dependencies:
   - pyspark==3.0.2
 
 spark:
-  tarball: https://downloads.apache.org/spark/spark-3.0.2/spark-3.0.2-bin-hadoop2.7.tgz
+  tarball: https://archive.apache.org/dist/spark/spark-3.0.2/spark-3.0.2-bin-hadoop2.7.tgz


### PR DESCRIPTION
Once a new version of Spark is released, the previous Spark version is
only available via the archive URL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/100)
<!-- Reviewable:end -->
