### PR TITLE
Ignore 'coverage' vulnerability

### DIFF
--- a/notebook-tests/tox.ini
+++ b/notebook-tests/tox.ini
@@ -32,7 +32,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     flake8 tests
-    safety check
+    safety check --ignore=41002
     mypy --ignore-missing-imports -p tests
 
 [testenv]


### PR DESCRIPTION
Effectively the vulnerability forces us to switch to a beta version of `coverage`,
thus we're ignoring this for now.
```
+============================+===========+==========================+==========+
 | coverage | 5.5 | <6.0b1 | 41002 |
+==============================================================================+
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/128)
<!-- Reviewable:end -->
