### PR TITLE
Remove via Nessie CLI comments in Spark3 demos

### DIFF
--- a/notebooks/nessie-delta-demo-nba.ipynb
+++ b/notebooks/nessie-delta-demo-nba.ipynb
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set up Nessie branches (via Nessie CLI)\n",
+    "Set up Nessie branches\n",
     "----------------------------\n",
     "Once all dependencies are configured, we can get started with ingesting our basketball data into `Nessie` with the following steps:\n",
     "\n",

--- a/notebooks/nessie-iceberg-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-demo-nba.ipynb
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set up Nessie branches (via Nessie CLI)\n",
+    "Set up Nessie branches\n",
     "----------------------------\n",
     "Once all dependencies are configured, we can get started with ingesting our basketball data into `Nessie` with the following steps:\n",
     "\n",


### PR DESCRIPTION
Since `nessie-delta-demo-nba.ipynb` and `nessie-iceberg-demo-nba.ipynb` demos use Spark3 API, I have removed `Via Nessie CLI` comment in create branch operation to avoid any confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/163)
<!-- Reviewable:end -->
