### PR TITLE
skip binder build for dependabot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   trigger-binder-build:
+    if: "!contains(github.event.commits[0].author.name, 'dependabot')"
     runs-on: ubuntu-latest
     steps:
       - uses: s-weigand/trigger-mybinder-build@v1


### PR DESCRIPTION
its expensive to build the binder image on every commit. This change helps us be a good citizen at mybinder and prevent frivolous rebuilds of our docker image there

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie-demos/175)
<!-- Reviewable:end -->
