### PR TITLE
Fix UnboundLocalError in error case

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:1862e40ba61960ec549097259a46a2b21fb6bba0
+FROM ghcr.io/projectnessie/nessie-binder-demos:7fb962b09182c5f60ac2f80bbabb693290f3f741
 
 # Create the necessary folders for the demo, this will be created and ownded by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets

--- a/notebooks/tests/__init__.py
+++ b/notebooks/tests/__init__.py
@@ -53,13 +53,15 @@ def _remove_folders(input_folders: [str]) -> None:
 def start_nessie() -> subprocess.Popen:
     """Context for starting and stopping a nessie binary."""
     start_command = _fetch_and_get_nessie_start_command()
+    p = None
     try:
         p = subprocess.Popen(  # noqa: S603
             start_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
         )
         yield p
     finally:
-        p.kill()
+        if p:
+            p.kill()
 
 
 def _fetch_and_get_nessie_start_command() -> [str]:


### PR DESCRIPTION
When the test-process cannot be started, the finally block errors out
with an UnboundLocalError.

Example:
```
          finally:
  >           p.kill()
  E           UnboundLocalError: local variable 'p' referenced before assignment

  tests/__init__.py:62: UnboundLocalError
```