### PR TITLE
Pin lint dependencies to bandit 1.7.2

### DIFF
--- a/notebooks/requirements_lint.txt
+++ b/notebooks/requirements_lint.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 -r requirements_dev.txt
+bandit==1.7.2
 black==22.1.0
 flake8-annotations
 flake8-bandit==2.1.2


### PR DESCRIPTION
Bandit core 1.7.3 was just released
(https://github.com/PyCQA/bandit/releases/tag/1.7.3) and the
flake8-bandit package uses this latest version. However, flake8 is
currently failing.

More specifically, the change in https://github.com/PyCQA/bandit/commit/0f4a4959bcc82665fc6bd7f575a87a12678d4484 is causing the below issue:
```
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/multiprocessing/pool.py", line 125, in worker
      result = (True, func(*args, **kwds))
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
      return list(map(*args))
    File "/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/flake8/checker.py", line 687, in _run_checks
      return checker.run_checks()
    File "/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/flake8/checker.py", line 597, in run_checks
      self.run_ast_checks()
    File "/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/flake8/checker.py", line 500, in run_ast_checks
      for (line_number, offset, text, _) in runner:
    File "/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/flake8_bandit.py", line 85, in run
      for warn in self._check_source():
    File "/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/flake8_bandit.py", line 59, in _check_source
      bnv = BanditNodeVisitor(
  TypeError: __init__() missing 1 required positional argument: 'metrics'
```

Therefore we temporarily pin the bandit version to 1.7.2 until the 1.7.3
version is compatible with flake8-bandit.

See also: https://github.com/projectnessie/nessie/pull/3458