### PR TITLE
Fix param for trigger-mybinder-build gh action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,4 @@ jobs:
       - uses: s-weigand/trigger-mybinder-build@v1
         with:
           target-repo: projectnessie/nessie-demos
+          target-state: main


### PR DESCRIPTION
silent errors i noticed on main CI:
```
Error for https://gke.mybinder.org/build/gh/projectnessie/nessie-demos:
Build Error https://gke.mybinder.org/build/gh/projectnessie/nessie-demos
Your binder build failed with the following
          message:
Spec is not of the form "user/repo/ref", provided: "projectnessie/nessie-demos". Did you mean "projectnessie/nessie-demos/master"?
```
https://github.com/projectnessie/nessie-demos/actions/runs/1911044917

looking at https://github.com/s-weigand/trigger-mybinder-build#inputs
the fix seems to be to specify the branch/commit explicitly.

since this action only runs on `main` it should be "okay" to trigger a build on the `main` branch instead of the current SHA for the running workflow, WDYT?