### PR TITLE
Tox and Bash improvements

### DIFF
--- a/.github/scripts/create_and_push_docker_image.sh
+++ b/.github/scripts/create_and_push_docker_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2020 Dremio
 #

--- a/.github/scripts/modify_dockerfile.sh
+++ b/.github/scripts/modify_dockerfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2020 Dremio
 #

--- a/.github/scripts/modify_dockerfile.sh
+++ b/.github/scripts/modify_dockerfile.sh
@@ -17,7 +17,7 @@
 
 # Install checksumdir to generate a reliable sha1 for Docker tags that
 # can detect the changes in content in a folder
-pip install checksumdir
+python -m pip install checksumdir
 
 CONTENT_FOLDER="docker/"
 BINDER_DOCKERFILE="binder/Dockerfile"

--- a/.github/workflows/demos-docker-build.yaml
+++ b/.github/workflows/demos-docker-build.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install jupyter-repo2docker
+        python -m pip install jupyter-repo2docker
     - name: Log in to the Github Container registry
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions build
+          python -m pip install tox tox-gh-actions build
       - name: Test Notebooks with Tox
         working-directory: notebooks/tests
         run: tox

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Regarding pre-commit, you will need to make sure is installed through `pre-commi
 executes some several scripts in pre-commit stage.
 
 To run the notebooks unit tests, in `notebook` folder, run the following commands:
-1. `pip install -r requirements_dev.txt`
+1. `python -m pip install -r requirements_dev.txt`
 2. `tox`
 
 Running the unit tests takes time since it will need to download all the binaries files like Hive, Flink ..etc and then it will

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,9 +2,9 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:7fb962b09182c5f60ac2f80bbabb693290f3f741
+FROM ghcr.io/projectnessie/nessie-binder-demos:28019582d70a0a86fd19a1653e3f8b364c6f82c8
 
-# Create the necessary folders for the demo, this will be created and ownded by {NB_USER}
+# Create the necessary folders for the demo, this will be created and owned by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets
 
 # Copy the python notebooks into the existing notebooks folder

--- a/binder/README.md
+++ b/binder/README.md
@@ -8,7 +8,7 @@ To build the binder image locally, firstly, you need to install `jupyter-repo2do
 
 ```shell
 python -m pip install --upgrade pip
-pip install jupyter-repo2docker
+python -m pip install jupyter-repo2docker
 ```
 
 ### Building the image

--- a/docker/binder/postBuild
+++ b/docker/binder/postBuild
@@ -21,7 +21,7 @@ python --version
 source /srv/conda/etc/profile.d/conda.sh
 conda create -n flink-demo pandas ipykernel requests python=="$PYTHON_VERSION"
 conda activate flink-demo
-pip install -r "binder/requirements_flink.txt"
+python -m pip install -r "binder/requirements_flink.txt"
 python -m ipykernel install --name "flink-demo" --user
 python -c "import utils;utils._copy_all_hadoop_jars_to_pyflink()"
 conda deactivate

--- a/docker/binder/postBuild
+++ b/docker/binder/postBuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2020 Dremio
 #
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-PYTHON_VERSION=`python --version|awk '{print $2}'`
+PYTHON_VERSION=$(python --version | awk '{print $2}')
 
 python --version
 source /srv/conda/etc/profile.d/conda.sh

--- a/docker/binder/start
+++ b/docker/binder/start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2020 Dremio
 #
@@ -17,9 +17,9 @@
 
 nohup ./nessie-quarkus-runner &
 
-SPARK_VERSION=`python -c "import utils;print(utils._SPARK_VERSION)"`
-HADOOP_VERSION=`python -c "import utils;print(utils._HADOOP_VERSION)"`
-HIVE_VERSION=`python -c "import utils;print(utils._HIVE_VERSION)"`
+SPARK_VERSION=$(python -c "import utils;print(utils._SPARK_VERSION)")
+HADOOP_VERSION=$(python -c "import utils;print(utils._HADOOP_VERSION)")
+HIVE_VERSION=$(python -c "import utils;print(utils._HIVE_VERSION)")
 
 export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 

--- a/docker/binder/start.hive
+++ b/docker/binder/start.hive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2020 Dremio
 #

--- a/notebooks/tests/scripts/start_hive
+++ b/notebooks/tests/scripts/start_hive
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/bash -e
 
 python -c "import utils;utils.fetch_hadoop()"
 
 python -c "import utils;utils.fetch_hive_with_iceberg_jars()"
 
-HADOOP_VERSION=`python -c "import utils;print(utils._HADOOP_VERSION)"`
+HADOOP_VERSION=$(python -c "import utils;print(utils._HADOOP_VERSION)")
 
-HIVE_VERSION=`python -c "import utils;print(utils._HIVE_VERSION)"`
+HIVE_VERSION=$(python -c "import utils;print(utils._HIVE_VERSION)")
 
 export HADOOP_HOME=$PWD/hadoop-$HADOOP_VERSION
 

--- a/notebooks/tox.ini
+++ b/notebooks/tox.ini
@@ -25,7 +25,6 @@ python =
 [testenv:flake8]
 basepython = python
 deps =
-    --use-deprecated=legacy-resolver
     -r{toxinidir}/requirements_lint.txt
 commands =
     flake8 tests
@@ -33,7 +32,7 @@ commands =
 [testenv:flink]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/../docker
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI CODECOV_*
 deps =
     --use-deprecated=legacy-resolver
     -r{toxinidir}/../docker/binder/requirements_flink.txt
@@ -42,29 +41,23 @@ commands =
     pytest --basetemp={envtmpdir} -ra tests/test_nessie_iceberg_flink_demo_nba.py
 
 [testenv:hive]
-whitelist_externals=
-    /bin/bash
+allowlist_externals=bash
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/../docker
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_* JAVA_HOME
+passenv = TOXENV CI CODECOV_* JAVA_HOME
 deps =
-    --use-deprecated=legacy-resolver
     -r{toxinidir}/../docker/binder/requirements.txt
     -r{toxinidir}/requirements_dev.txt
 commands =
-    bash -ec 'chmod +x {toxinidir}/tests/scripts/start_hive'
-    bash -ec '{toxinidir}/tests/scripts/start_hive'
-    pip install -U pip
+    bash -ex {toxinidir}/tests/scripts/start_hive
     pytest --basetemp={envtmpdir} -ra tests/test_nessie_iceberg_hive_demo_nba.py
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/../docker
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI CODECOV_*
 deps =
-    --use-deprecated=legacy-resolver
     -r{toxinidir}/../docker/binder/requirements.txt
     -r{toxinidir}/requirements_dev.txt
 commands =
-    pip install -U pip
     pytest --basetemp={envtmpdir} -ra tests --ignore tests/test_nessie_iceberg_flink_demo_nba.py --ignore tests/test_nessie_iceberg_hive_demo_nba.py


### PR DESCRIPTION
some LHF improvements to clean things up and make them stricter/fail early.

also partially reverts https://github.com/projectnessie/nessie-demos/pull/263 in cases where using the improved pip resolver is fine (it prevents dependabot from upgrading dependencies into unsupported combinations, see the comment about `Sphinx`).

We have to keep it for flink for now because the transitive dependencies there are a huge mess.