### PR TITLE
Remove unused Sphinx dependency

### DIFF
--- a/notebooks/requirements_dev.txt
+++ b/notebooks/requirements_dev.txt
@@ -25,8 +25,6 @@ pytest==7.0.1
 pytest-mock==3.7.0
 pytest-mypy==0.9.1
 pytest-runner==6.0.0
-Sphinx==4.4.0
-sphinx-autodoc-typehints==1.17.0
 testbook[dev]==0.4.2
 tox==3.24.5
 twine==3.8.0


### PR DESCRIPTION
split out from https://github.com/projectnessie/nessie-demos/pull/280

Sphinx 4.4.0 is not compatible with the latest version of flake8:
```
   The conflict is caused by:
      build 0.7.0 depends on importlib-metadata>=0.22; python_version < "3.8"
      flake8 4.0.1 depends on importlib-metadata<4.3; python_version < "3.8"
      pytest 7.0.1 depends on importlib-metadata>=0.12; python_version < "3.8"
      sphinx 4.4.0 depends on importlib-metadata>=4.4; python_version < "3.10"
```
using the proper / non-legacy pip resolver prevents dependabot from making invalid version upgrades in the future.

turns out sphinx isnt actually used in the project and we can just remove it:
https://github.com/projectnessie/nessie-demos/search?q=sphinx&type=code