### PR TITLE
Pin all python dependencies

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:28019582d70a0a86fd19a1653e3f8b364c6f82c8
+FROM ghcr.io/projectnessie/nessie-binder-demos:982fe3adb1e8b58263c74d0b3fc4b6b9ab97f652
 
 # Create the necessary folders for the demo, this will be created and owned by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets

--- a/docker/binder/requirements.txt
+++ b/docker/binder/requirements.txt
@@ -1,4 +1,5 @@
 -r requirements_base.txt
-findspark
+findspark==2.0.1
+pandas==1.3.5
 pyhive[hive]==0.6.4
 pyspark==3.1.2

--- a/docker/binder/requirements_base.txt
+++ b/docker/binder/requirements_base.txt
@@ -1,2 +1,1 @@
-pandas
 pynessie==0.9.2

--- a/docker/binder/requirements_flink.txt
+++ b/docker/binder/requirements_flink.txt
@@ -1,2 +1,4 @@
 -r requirements_base.txt
 apache-flink==1.12.1
+# flink requires pandas<1 see https://github.com/apache/flink/blob/release-1.12.1/flink-python/setup.py#L319-L320
+pandas==0.25.3

--- a/notebooks/requirements_dev.txt
+++ b/notebooks/requirements_dev.txt
@@ -17,7 +17,6 @@
 assertpy==1.1
 bump2version==1.0.1
 build==0.7.0
-flake8==4.0.1
 ipython==7.32.0
 jupyterlab==3.2.9
 pip==22.0.3

--- a/notebooks/requirements_dev.txt
+++ b/notebooks/requirements_dev.txt
@@ -18,7 +18,7 @@ assertpy==1.1
 bump2version==1.0.1
 build==0.7.0
 flake8==4.0.1
-ipython
+ipython==7.32.0
 jupyterlab==3.2.9
 pip==22.0.3
 pytest==7.0.1

--- a/notebooks/requirements_lint.txt
+++ b/notebooks/requirements_lint.txt
@@ -16,6 +16,7 @@
 -r requirements_dev.txt
 bandit==1.7.2
 black==22.1.0
+flake8==4.0.1
 flake8-annotations==2.7.0
 flake8-bandit==2.1.2
 flake8-black==0.3.2

--- a/notebooks/requirements_lint.txt
+++ b/notebooks/requirements_lint.txt
@@ -16,7 +16,7 @@
 -r requirements_dev.txt
 bandit==1.7.2
 black==22.1.0
-flake8-annotations
+flake8-annotations==2.7.0
 flake8-bandit==2.1.2
 flake8-black==0.3.2
 flake8-bugbear==22.1.11


### PR DESCRIPTION
Split out from https://github.com/projectnessie/nessie-demos/pull/280

we should pin all dependencies to avoid random new version releases form affecting our build.

however in the `pandas` case we relied on pip selecting the right version for us, which needs to be compatible with the (strange) flink dependencies, thus we are now pinning different versions in the respective requirement files.

also noticed that `flake8` was in the `dev` requirements, while its plugins where in the `lint` requirements, which does not make much sense.
Since we are now using the more restrictive pip dependency resolver (see https://github.com/projectnessie/nessie-demos/pull/280) we should clean up this inconsistency to avoid incompatibilities going forward.

