### PR TITLE
CI: Add information to dependabot-automerge WF

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,9 +37,30 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.actor == 'dependabot[bot]' && (
         startsWith(github.event.workflow_run.head_commit.message, 'Bump')
-      )
+      ) &&
+      github.repository == 'projectnessie/nessie-demos'
 
     steps:
+      - name: Information
+        uses: "actions/github-script@v6"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const pullRequest = context.payload.workflow_run.pull_requests[0]
+            const repository = context.repo
+            const pullRequestDetails = await github.rest.pulls.get({
+              owner: repository.owner,
+              repo: repository.repo,
+              pull_number: pullRequest.number,
+            })
+
+            console.log("PR Number: " + pullRequest.number)
+            console.log("PR Title: " + pullRequestDetails.data.title)
+            console.log("PR head SHA: " + pullRequest.head.sha)
+            console.log("PR head ref: " + pullRequest.head.ref)
+            console.log("PR URL: " + pullRequestDetails.data.html_url)
+            console.log(pullRequestDetails)
+
       - name: Check commit status
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
@@ -58,6 +79,7 @@ jobs:
               owner: repository.owner,
               repo: repository.repo,
               pull_number: pullRequest.number,
+              commit_id: pullRequest.head.sha,
             })
 
       - name: "Merge pull request"
@@ -73,4 +95,5 @@ jobs:
               owner: repository.owner,
               pull_number: pullRequest.number,
               repo: repository.repo,
+              commit_id: pullRequest.head.sha,
             })


### PR DESCRIPTION
Dump information about the PR in a separate WF set and
ensure that approve + merge only happen when the PR's not been changed.