### PR TITLE
Fix `Dependabot Auto Merge`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ on:
     types:
       - "completed"
     workflows:
-      - "CI"
+      - "Testing Jupyter Notebooks"
 
 jobs:
   merge:


### PR DESCRIPTION
... workflow trigger configured for the wrong (non-existent) workflow.