### PR TITLE
Fix dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.actor == 'dependabot[bot]' && (
-        contains(github.event.workflow_run.head_commit.message, 'ump ') // starts-with or contains "[Bb]ump"
+        contains(github.event.workflow_run.head_commit.message, 'ump ')
       ) &&
       github.repository == 'projectnessie/nessie-demos'
 


### PR DESCRIPTION
Fixes
```
The workflow is not valid. .github/workflows/dependabot-auto-merge.yml (Line: 35, Col: 9): Unexpected symbol: '//'. 
```
