### PR TITLE
Adjust mybinder URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 These demos run under binder and can be found at:
 
-* [Spark and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-demo-nba.ipynb)
-* [Spark and Delta](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-delta-demo-nba.ipynb)
-* [Flink and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-flink-demo-nba.ipynb)
-* [Hive and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-hive-demo-nba.ipynb)
+* [Spark and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?labpath=notebooks%2Fnessie-iceberg-demo-nba.ipynb)
+* [Spark and Delta](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?labpath=notebooks%2Fnessie-delta-demo-nba.ipynb)
+* [Flink and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?labpath=notebooks%2Fnessie-iceberg-flink-demo-nba.ipynb)
+* [Hive and Iceberg](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?labpath=notebooks%2Fnessie-iceberg-hive-demo-nba.ipynb)
 
 They are automatically rebuilt every time we push to main. They are unit tested using `testbook` library to ensure we get
 the correct results as the underlying libraries continue to grow/mature.

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:8e435724242f8ff526e1899418f9d27d5d14acb5
+FROM ghcr.io/projectnessie/nessie-binder-demos:b06db7472c61543d26e3ce8e3e8a3ea6ef488fef
 
 # Create the necessary folders for the demo, this will be created and owned by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets


### PR DESCRIPTION
Mybinder slightly changed the generated URLs.

Old:
`https://mybinder.org/v2/gh/XN137/nessie-demos/latest-nessie-version?filepath=notebooks/nessie-iceberg-demo-nba.ipynb`
New:
`https://mybinder.org/v2/gh/XN137/nessie-demos/latest-nessie-version?labpath=notebooks%2Fnessie-iceberg-demo-nba.ipynb`