### PR TITLE
Fix checksumdir not ignoring __pycache__ content

### DIFF
--- a/.github/scripts/modify_dockerfile.sh
+++ b/.github/scripts/modify_dockerfile.sh
@@ -23,7 +23,7 @@ CONTENT_FOLDER="docker/"
 BINDER_DOCKERFILE="binder/Dockerfile"
 
 # Generate the sha1 for the content of the folder
-DOCKER_TAG="$(checksumdir -i -e '__pycache__' -a sha1 $CONTENT_FOLDER)"
+DOCKER_TAG="$(checksumdir --ignore-hidden --excluded-extensions pyc --algorithm sha1 $CONTENT_FOLDER)"
 
 # Change the tag in Dockerfile
 sed -i.bak -E "s/(FROM.*:).*/\1$DOCKER_TAG/" $BINDER_DOCKERFILE

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -51,6 +51,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions build
       - name: Check Dockerfile hash is up-to-date
+        if: github.actor != 'dependabot[bot]'
         run: |
           bash -ex .github/scripts/modify_dockerfile.sh
           changed_hash=$(git status --porcelain binder/Dockerfile)

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -50,6 +50,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions build
+      - name: Check Dockerfile hash is up-to-date
+        run: |
+          bash -ex .github/scripts/modify_dockerfile.sh
+          changed_hash=$(git status --porcelain binder/Dockerfile)
+          if [ -n "$changed_hash" ]; then
+            echo "ERROR: Dockerfile hash is out of sync!"
+            tree docker
+            grep FROM binder/Dockerfile
+            exit 1
+          fi
+          echo "PASSED: Dockerfile hash is up-to-date!"
       - name: Test Notebooks with Tox
         working-directory: notebooks/tests
         run: tox

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:111111111fa7d9666178380a33b2e645a52d5985
+FROM ghcr.io/projectnessie/nessie-binder-demos:649ec80b8fa7d9666178380a33b2e645a52d5985
 
 # Create the necessary folders for the demo, this will be created and owned by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag will be automatically generated through pre-commit hook if any changes
 # happened in the docker/ folder
-FROM ghcr.io/projectnessie/nessie-binder-demos:649ec80b8fa7d9666178380a33b2e645a52d5985
+FROM ghcr.io/projectnessie/nessie-binder-demos:111111111fa7d9666178380a33b2e645a52d5985
 
 # Create the necessary folders for the demo, this will be created and owned by {NB_USER}
 RUN mkdir -p notebooks && mkdir -p datasets


### PR DESCRIPTION
in https://github.com/projectnessie/nessie-demos/pull/339 we noticed that the hash is different on another machine.
found out its because the __pycache__ content is not ignored, see below.
we also add a github workflow check to make sure PRs update the hash as CI would expect it to be.

before:
```
(venv) chris@xanadu:~/code/nessie-demos$ tree docker/
docker/
├── binder
│   ├── apt.txt
│   ├── postBuild
│   ├── requirements_base.txt
│   ├── requirements_flink.txt
│   ├── requirements.txt
│   ├── resources
│   │   └── hive
│   │       └── config
│   │           └── hive-site.xml
│   ├── start
│   └── start.hive
└── utils
    ├── __init__.py
    └── __pycache__
        └── __init__.cpython-39.pyc

6 directories, 10 files
(venv) chris@xanadu:~/code/nessie-demos$ checksumdir -i -e '__pycache__' -a sha1 docker/
8e435724242f8ff526e1899418f9d27d5d14acb5
```

after:
```
(venv) chris@xanadu:~/code/nessie-demos$ tree docker/
docker/
├── binder
│   ├── apt.txt
│   ├── postBuild
│   ├── requirements_base.txt
│   ├── requirements_flink.txt
│   ├── requirements.txt
│   ├── resources
│   │   └── hive
│   │       └── config
│   │           └── hive-site.xml
│   ├── start
│   └── start.hive
└── utils
    ├── __init__.py
    └── __pycache__
        └── __init__.cpython-39.pyc

6 directories, 10 files
(venv) chris@xanadu:~/code/nessie-demos$ checksumdir -i -x pyc -a sha1 docker/
b06db7472c61543d26e3ce8e3e8a3ea6ef488fef
```

sidenote: directories without files dont matter for the hash
```
(venv) chris@xanadu:~/code/nessie-demos$ checksumdir --ignore-hidden --excluded-extensions pyc --algorithm sha1 docker/
b06db7472c61543d26e3ce8e3e8a3ea6ef488fef
(venv) chris@xanadu:~/code/nessie-demos$ mkdir -p docker/foo/bar/baz
(venv) chris@xanadu:~/code/nessie-demos$ checksumdir --ignore-hidden --excluded-extensions pyc --algorithm sha1 docker/
b06db7472c61543d26e3ce8e3e8a3ea6ef488fef
```

