### PR TITLE
Format + clean notebook cell output with nbstripout

### DIFF
--- a/notebooks/nessie-delta-demo-nba.ipynb
+++ b/notebooks/nessie-delta-demo-nba.ipynb
@@ -20,33 +20,77 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "WARNING: An illegal reflective access operation has occurred\nWARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/spark-unsafe_2.12-3.2.1.jar) to constructor java.nio.DirectByteBuffer(long,int)\nWARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\nWARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\nWARNING: All illegal access operations will be denied in a future release\nhttps://storage.googleapis.com/nessie-maven added as a remote repository with the name: repo-1\nIvy Default Cache set to: /home/jovyan/.ivy2/cache\nThe jars for the packages stored in: /home/jovyan/.ivy2/jars\norg.projectnessie#nessie-deltalake added as a dependency\norg.projectnessie#nessie-spark-3.2-extensions added as a dependency\n:: resolving dependencies :: org.apache.spark#spark-submit-parent-2ab7f1e0-01bb-42fd-bb2f-6c1b59cdc6dd;1.0\n\tconfs: [default]\n"
+          "text": [
+            "WARNING: An illegal reflective access operation has occurred\n",
+            "WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/spark-unsafe_2.12-3.2.1.jar) to constructor java.nio.DirectByteBuffer(long,int)\n",
+            "WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\n",
+            "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
+            "WARNING: All illegal access operations will be denied in a future release\n",
+            "https://storage.googleapis.com/nessie-maven added as a remote repository with the name: repo-1\n",
+            "Ivy Default Cache set to: /home/jovyan/.ivy2/cache\n",
+            "The jars for the packages stored in: /home/jovyan/.ivy2/jars\n",
+            "org.projectnessie#nessie-deltalake added as a dependency\n",
+            "org.projectnessie#nessie-spark-3.2-extensions added as a dependency\n",
+            ":: resolving dependencies :: org.apache.spark#spark-submit-parent-2ab7f1e0-01bb-42fd-bb2f-6c1b59cdc6dd;1.0\n",
+            "\tconfs: [default]\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": ":: loading settings :: url = jar:file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml\n"
+          "text": [
+            ":: loading settings :: url = jar:file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml\n"
+          ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "\tfound org.projectnessie#nessie-deltalake;0.30.0 in central\n\tfound org.antlr#antlr4-runtime;4.9.2 in central\n\tfound org.projectnessie#nessie-spark-3.2-extensions;0.30.0 in central\ndownloading https://repo1.maven.org/maven2/org/projectnessie/nessie-deltalake/0.30.0/nessie-deltalake-0.30.0.jar ...\n\t[SUCCESSFUL ] org.projectnessie#nessie-deltalake;0.30.0!nessie-deltalake.jar (375ms)\ndownloading https://repo1.maven.org/maven2/org/projectnessie/nessie-spark-3.2-extensions/0.30.0/nessie-spark-3.2-extensions-0.30.0.jar ...\n\t[SUCCESSFUL ] org.projectnessie#nessie-spark-3.2-extensions;0.30.0!nessie-spark-3.2-extensions.jar (87ms)\ndownloading https://repo1.maven.org/maven2/org/antlr/antlr4-runtime/4.9.2/antlr4-runtime-4.9.2.jar ...\n\t[SUCCESSFUL ] org.antlr#antlr4-runtime;4.9.2!antlr4-runtime.jar (59ms)\n:: resolution report :: resolve 19292ms :: artifacts dl 524ms\n\t:: modules in use:\n\torg.antlr#antlr4-runtime;4.9.2 from central in [default]\n\torg.projectnessie#nessie-deltalake;0.30.0 from central in [default]\n\torg.projectnessie#nessie-spark-3.2-extensions;0.30.0 from central in [default]\n\t---------------------------------------------------------------------\n\t|                  |            modules            ||   artifacts   |\n\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n\t---------------------------------------------------------------------\n\t|      default     |   3   |   3   |   3   |   0   ||   3   |   3   |\n\t---------------------------------------------------------------------\n:: retrieving :: org.apache.spark#spark-submit-parent-2ab7f1e0-01bb-42fd-bb2f-6c1b59cdc6dd\n\tconfs: [default]\n\t3 artifacts copied, 0 already retrieved (4023kB/6ms)\n22/05/24 07:49:11 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\nUsing Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\nSetting default log level to \"WARN\".\nTo adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+          "text": [
+            "\tfound org.projectnessie#nessie-deltalake;0.30.0 in central\n",
+            "\tfound org.antlr#antlr4-runtime;4.9.2 in central\n",
+            "\tfound org.projectnessie#nessie-spark-3.2-extensions;0.30.0 in central\n",
+            "downloading https://repo1.maven.org/maven2/org/projectnessie/nessie-deltalake/0.30.0/nessie-deltalake-0.30.0.jar ...\n",
+            "\t[SUCCESSFUL ] org.projectnessie#nessie-deltalake;0.30.0!nessie-deltalake.jar (375ms)\n",
+            "downloading https://repo1.maven.org/maven2/org/projectnessie/nessie-spark-3.2-extensions/0.30.0/nessie-spark-3.2-extensions-0.30.0.jar ...\n",
+            "\t[SUCCESSFUL ] org.projectnessie#nessie-spark-3.2-extensions;0.30.0!nessie-spark-3.2-extensions.jar (87ms)\n",
+            "downloading https://repo1.maven.org/maven2/org/antlr/antlr4-runtime/4.9.2/antlr4-runtime-4.9.2.jar ...\n",
+            "\t[SUCCESSFUL ] org.antlr#antlr4-runtime;4.9.2!antlr4-runtime.jar (59ms)\n",
+            ":: resolution report :: resolve 19292ms :: artifacts dl 524ms\n",
+            "\t:: modules in use:\n",
+            "\torg.antlr#antlr4-runtime;4.9.2 from central in [default]\n",
+            "\torg.projectnessie#nessie-deltalake;0.30.0 from central in [default]\n",
+            "\torg.projectnessie#nessie-spark-3.2-extensions;0.30.0 from central in [default]\n",
+            "\t---------------------------------------------------------------------\n",
+            "\t|                  |            modules            ||   artifacts   |\n",
+            "\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n",
+            "\t---------------------------------------------------------------------\n",
+            "\t|      default     |   3   |   3   |   3   |   0   ||   3   |   3   |\n",
+            "\t---------------------------------------------------------------------\n",
+            ":: retrieving :: org.apache.spark#spark-submit-parent-2ab7f1e0-01bb-42fd-bb2f-6c1b59cdc6dd\n",
+            "\tconfs: [default]\n",
+            "\t3 artifacts copied, 0 already retrieved (4023kB/6ms)\n",
+            "22/05/24 07:49:11 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+            "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
+            "Setting default log level to \"WARN\".\n",
+            "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "Spark Running\n"
+          "text": [
+            "Spark Running\n"
+          ]
         }
       ],
       "source": [
@@ -121,17 +165,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType name                                               hash\n0  Branch  dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType name                                               hash\n",
+              "0  Branch  dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 2,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -151,17 +230,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch   dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...\n1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch   dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...\n",
+              "1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 3,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -193,22 +314,51 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "                                                                                \r"
+          "text": [
+            "                                                                                \r"
+          ]
         },
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 4,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -255,22 +405,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "50\n92\n"
+          "text": [
+            "50\n",
+            "92\n"
+          ]
         }
       ],
       "source": [
@@ -301,22 +452,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -332,15 +483,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -360,17 +514,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab...\n1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab...\n",
+              "1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 8,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -392,17 +588,50 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>main</td>\n      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   name                                               hash\n0  main  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>main</td>\n",
+              "      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   name                                               hash\n",
+              "0  main  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921..."
+            ]
           },
-          "execution_count": 9,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -422,17 +651,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch  main  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...\n1  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch  main  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...\n",
+              "1  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab..."
+            ]
           },
-          "execution_count": 10,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -443,15 +714,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -460,15 +734,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "50\n92\n"
+          "text": [
+            "50\n",
+            "92\n"
+          ]
         }
       ],
       "source": [
@@ -505,17 +780,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>etl</td>\n      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType name                                               hash\n0  Branch  etl  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>etl</td>\n",
+              "      <td>dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType name                                               hash\n",
+              "0  Branch  etl  dee6e3ec017cd39a272ccd4599bc2f1d4679731bd7b921..."
+            ]
           },
-          "execution_count": 13,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -526,20 +836,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 14,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -559,17 +897,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 15,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -581,17 +946,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>47</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        47"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>47</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        47"
+            ]
           },
-          "execution_count": 16,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -625,15 +1021,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -642,15 +1041,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -666,24 +1069,57 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>main</td>\n      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   name                                               hash\n0  main  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>main</td>\n",
+              "      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   name                                               hash\n",
+              "0  main  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9..."
+            ]
           },
-          "execution_count": 19,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -701,22 +1137,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -725,17 +1165,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>etl</td>\n      <td>2d11823828ee539d7609e1a88083ada6f37d39362a4e3a...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch  main  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...\n1  Branch   etl  2d11823828ee539d7609e1a88083ada6f37d39362a4e3a...\n2  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>etl</td>\n",
+              "      <td>2d11823828ee539d7609e1a88083ada6f37d39362a4e3a...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>54622696d1313cfcb012120083d917f65558f0906f73ab...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch  main  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...\n",
+              "1  Branch   etl  2d11823828ee539d7609e1a88083ada6f37d39362a4e3a...\n",
+              "2  Branch   dev  54622696d1313cfcb012120083d917f65558f0906f73ab..."
+            ]
           },
-          "execution_count": 21,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -746,15 +1235,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "47\n"
+          "text": [
+            "47\n"
+          ]
         }
       ],
       "source": [
@@ -781,17 +1270,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>experiment</td>\n      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType        name                                               hash\n0  Branch  experiment  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>experiment</td>\n",
+              "      <td>cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType        name                                               hash\n",
+              "0  Branch  experiment  cdf244cd4af77968becc0ebd0439efea6c6e6df8923ed9..."
+            ]
           },
-          "execution_count": 23,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -803,17 +1327,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 24,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -825,17 +1376,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 25,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -854,15 +1432,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -871,22 +1453,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "DELTA_LAKE_TABLE:\n\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n\n"
+          "text": [
+            "DELTA_LAKE_TABLE:\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.salaries._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.totals_stats._delta_log\n",
+            "\thome.jovyan.notebooks.spark_warehouse.delta.allstar_stats._delta_log\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -903,17 +1489,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>58</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        58"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>58</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        58"
+            ]
           },
-          "execution_count": 28,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -932,20 +1549,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>54</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        54"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>54</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        54"
+            ]
           },
-          "execution_count": 29,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -968,19 +1617,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "DataFrame[status: string]"
+            "text/plain": [
+              "DataFrame[status: string]"
+            ]
           },
-          "execution_count": 30,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }

--- a/notebooks/nessie-iceberg-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-demo-nba.ipynb
@@ -20,33 +20,72 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "WARNING: An illegal reflective access operation has occurred\nWARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/spark-unsafe_2.12-3.2.1.jar) to constructor java.nio.DirectByteBuffer(long,int)\nWARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\nWARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\nWARNING: All illegal access operations will be denied in a future release\nIvy Default Cache set to: /home/jovyan/.ivy2/cache\nThe jars for the packages stored in: /home/jovyan/.ivy2/jars\norg.apache.iceberg#iceberg-spark-runtime-3.2_2.12 added as a dependency\norg.projectnessie#nessie-spark-3.2-extensions added as a dependency\n:: resolving dependencies :: org.apache.spark#spark-submit-parent-6cba98e4-6e15-458e-a366-568683d289f7;1.0\n\tconfs: [default]\n"
+          "text": [
+            "WARNING: An illegal reflective access operation has occurred\n",
+            "WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/spark-unsafe_2.12-3.2.1.jar) to constructor java.nio.DirectByteBuffer(long,int)\n",
+            "WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\n",
+            "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
+            "WARNING: All illegal access operations will be denied in a future release\n",
+            "Ivy Default Cache set to: /home/jovyan/.ivy2/cache\n",
+            "The jars for the packages stored in: /home/jovyan/.ivy2/jars\n",
+            "org.apache.iceberg#iceberg-spark-runtime-3.2_2.12 added as a dependency\n",
+            "org.projectnessie#nessie-spark-3.2-extensions added as a dependency\n",
+            ":: resolving dependencies :: org.apache.spark#spark-submit-parent-6cba98e4-6e15-458e-a366-568683d289f7;1.0\n",
+            "\tconfs: [default]\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": ":: loading settings :: url = jar:file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml\n"
+          "text": [
+            ":: loading settings :: url = jar:file:/home/jovyan/spark-3.2.1-bin-hadoop3.2/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml\n"
+          ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "\tfound org.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1 in central\n\tfound org.projectnessie#nessie-spark-3.2-extensions;0.30.0 in central\ndownloading https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.13.1/iceberg-spark-runtime-3.2_2.12-0.13.1.jar ...\n\t[SUCCESSFUL ] org.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1!iceberg-spark-runtime-3.2_2.12.jar (1331ms)\ndownloading https://repo1.maven.org/maven2/org/projectnessie/nessie-spark-3.2-extensions/0.30.0/nessie-spark-3.2-extensions-0.30.0.jar ...\n\t[SUCCESSFUL ] org.projectnessie#nessie-spark-3.2-extensions;0.30.0!nessie-spark-3.2-extensions.jar (70ms)\n:: resolution report :: resolve 13309ms :: artifacts dl 1405ms\n\t:: modules in use:\n\torg.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1 from central in [default]\n\torg.projectnessie#nessie-spark-3.2-extensions;0.30.0 from central in [default]\n\t---------------------------------------------------------------------\n\t|                  |            modules            ||   artifacts   |\n\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n\t---------------------------------------------------------------------\n\t|      default     |   2   |   2   |   2   |   0   ||   2   |   2   |\n\t---------------------------------------------------------------------\n:: retrieving :: org.apache.spark#spark-submit-parent-6cba98e4-6e15-458e-a366-568683d289f7\n\tconfs: [default]\n\t2 artifacts copied, 0 already retrieved (22360kB/20ms)\n22/05/24 07:43:12 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\nUsing Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\nSetting default log level to \"WARN\".\nTo adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+          "text": [
+            "\tfound org.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1 in central\n",
+            "\tfound org.projectnessie#nessie-spark-3.2-extensions;0.30.0 in central\n",
+            "downloading https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.13.1/iceberg-spark-runtime-3.2_2.12-0.13.1.jar ...\n",
+            "\t[SUCCESSFUL ] org.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1!iceberg-spark-runtime-3.2_2.12.jar (1331ms)\n",
+            "downloading https://repo1.maven.org/maven2/org/projectnessie/nessie-spark-3.2-extensions/0.30.0/nessie-spark-3.2-extensions-0.30.0.jar ...\n",
+            "\t[SUCCESSFUL ] org.projectnessie#nessie-spark-3.2-extensions;0.30.0!nessie-spark-3.2-extensions.jar (70ms)\n",
+            ":: resolution report :: resolve 13309ms :: artifacts dl 1405ms\n",
+            "\t:: modules in use:\n",
+            "\torg.apache.iceberg#iceberg-spark-runtime-3.2_2.12;0.13.1 from central in [default]\n",
+            "\torg.projectnessie#nessie-spark-3.2-extensions;0.30.0 from central in [default]\n",
+            "\t---------------------------------------------------------------------\n",
+            "\t|                  |            modules            ||   artifacts   |\n",
+            "\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n",
+            "\t---------------------------------------------------------------------\n",
+            "\t|      default     |   2   |   2   |   2   |   0   ||   2   |   2   |\n",
+            "\t---------------------------------------------------------------------\n",
+            ":: retrieving :: org.apache.spark#spark-submit-parent-6cba98e4-6e15-458e-a366-568683d289f7\n",
+            "\tconfs: [default]\n",
+            "\t2 artifacts copied, 0 already retrieved (22360kB/20ms)\n",
+            "22/05/24 07:43:12 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+            "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
+            "Setting default log level to \"WARN\".\n",
+            "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "Spark Running\n"
+          "text": [
+            "Spark Running\n"
+          ]
         }
       ],
       "source": [
@@ -117,17 +156,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType name                                               hash\n0  Branch  dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType name                                               hash\n",
+              "0  Branch  dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 2,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -147,17 +221,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch   dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...\n1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch   dev  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...\n",
+              "1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 3,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -189,17 +305,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 4,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -242,22 +385,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "50\n92\n"
+          "text": [
+            "50\n",
+            "92\n"
+          ]
         }
       ],
       "source": [
@@ -284,24 +428,54 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: [namespace, tableName, isTemporary]\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: [namespace, tableName, isTemporary]\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 6,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -320,17 +494,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace     tableName  isTemporary\n0       nba  totals_stats        False\n1       nba      salaries        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace     tableName  isTemporary\n",
+              "0       nba  totals_stats        False\n",
+              "1       nba      salaries        False"
+            ]
           },
-          "execution_count": 7,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -353,17 +569,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137...\n1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137...\n",
+              "1  Branch  main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616a..."
+            ]
           },
-          "execution_count": 8,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -385,17 +643,50 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>main</td>\n      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   name                                               hash\n0  main  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>main</td>\n",
+              "      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   name                                               hash\n",
+              "0  main  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38..."
+            ]
           },
-          "execution_count": 9,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -415,17 +706,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch  main  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...\n1  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch  main  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...\n",
+              "1  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137..."
+            ]
           },
-          "execution_count": 10,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -436,17 +769,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace     tableName  isTemporary\n0       nba      salaries        False\n1       nba  totals_stats        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace     tableName  isTemporary\n",
+              "0       nba      salaries        False\n",
+              "1       nba  totals_stats        False"
+            ]
           },
-          "execution_count": 11,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -458,15 +833,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "50\n92\n"
+          "text": [
+            "50\n",
+            "92\n"
+          ]
         }
       ],
       "source": [
@@ -502,17 +878,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>etl</td>\n      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType name                                               hash\n0  Branch  etl  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>etl</td>\n",
+              "      <td>af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType name                                               hash\n",
+              "0  Branch  etl  af5e8edd1b769f3840ee485c0c6fc6aeaaebeb10d6ad38..."
+            ]
           },
-          "execution_count": 13,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -523,20 +934,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 14,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -556,17 +995,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 15,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -578,17 +1044,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>47</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        47"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>47</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        47"
+            ]
           },
-          "execution_count": 16,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -620,17 +1117,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace     tableName  isTemporary\n0       nba      salaries        False\n1       nba  totals_stats        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace     tableName  isTemporary\n",
+              "0       nba      salaries        False\n",
+              "1       nba  totals_stats        False"
+            ]
           },
-          "execution_count": 17,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -642,17 +1181,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>allstar_games_stats</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace            tableName  isTemporary\n0       nba  allstar_games_stats        False\n1       nba         totals_stats        False\n2       nba             salaries        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>allstar_games_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace            tableName  isTemporary\n",
+              "0       nba  allstar_games_stats        False\n",
+              "1       nba         totals_stats        False\n",
+              "2       nba             salaries        False"
+            ]
           },
-          "execution_count": 18,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -671,24 +1259,57 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>main</td>\n      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   name                                               hash\n0  main  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>main</td>\n",
+              "      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   name                                               hash\n",
+              "0  main  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2..."
+            ]
           },
-          "execution_count": 19,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -706,24 +1327,73 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>allstar_games_stats</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace            tableName  isTemporary\n0       nba             salaries        False\n1       nba  allstar_games_stats        False\n2       nba         totals_stats        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>allstar_games_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace            tableName  isTemporary\n",
+              "0       nba             salaries        False\n",
+              "1       nba  allstar_games_stats        False\n",
+              "2       nba         totals_stats        False"
+            ]
           },
-          "execution_count": 20,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -735,17 +1405,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>main</td>\n      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Branch</td>\n      <td>etl</td>\n      <td>957c1254ab0a3e3bd1e306669ebe7073e27a97966bcfda...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Branch</td>\n      <td>dev</td>\n      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType  name                                               hash\n0  Branch  main  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...\n1  Branch   etl  957c1254ab0a3e3bd1e306669ebe7073e27a97966bcfda...\n2  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>main</td>\n",
+              "      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>etl</td>\n",
+              "      <td>957c1254ab0a3e3bd1e306669ebe7073e27a97966bcfda...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>dev</td>\n",
+              "      <td>70a8df769b477de5b9157691edef1efca8a640ae9f7137...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType  name                                               hash\n",
+              "0  Branch  main  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...\n",
+              "1  Branch   etl  957c1254ab0a3e3bd1e306669ebe7073e27a97966bcfda...\n",
+              "2  Branch   dev  70a8df769b477de5b9157691edef1efca8a640ae9f7137..."
+            ]
           },
-          "execution_count": 21,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -756,15 +1475,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "47\n"
+          "text": [
+            "47\n"
+          ]
         }
       ],
       "source": [
@@ -790,17 +1509,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>refType</th>\n      <th>name</th>\n      <th>hash</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Branch</td>\n      <td>experiment</td>\n      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  refType        name                                               hash\n0  Branch  experiment  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2..."
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>refType</th>\n",
+              "      <th>name</th>\n",
+              "      <th>hash</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Branch</td>\n",
+              "      <td>experiment</td>\n",
+              "      <td>e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  refType        name                                               hash\n",
+              "0  Branch  experiment  e0f4167c8947d15161a8fedc376da020f1ecff63c5eea2..."
+            ]
           },
-          "execution_count": 23,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -812,17 +1566,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 24,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -834,17 +1615,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "Empty DataFrame\nColumns: []\nIndex: []"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: []\n",
+              "Index: []"
+            ]
           },
-          "execution_count": 25,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -863,17 +1671,59 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>allstar_games_stats</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace            tableName  isTemporary\n0       nba             salaries        False\n1       nba  allstar_games_stats        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>allstar_games_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace            tableName  isTemporary\n",
+              "0       nba             salaries        False\n",
+              "1       nba  allstar_games_stats        False"
+            ]
           },
-          "execution_count": 26,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -884,24 +1734,73 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>namespace</th>\n      <th>tableName</th>\n      <th>isTemporary</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>nba</td>\n      <td>salaries</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>nba</td>\n      <td>allstar_games_stats</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>nba</td>\n      <td>totals_stats</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "  namespace            tableName  isTemporary\n0       nba             salaries        False\n1       nba  allstar_games_stats        False\n2       nba         totals_stats        False"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>namespace</th>\n",
+              "      <th>tableName</th>\n",
+              "      <th>isTemporary</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>salaries</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>allstar_games_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>nba</td>\n",
+              "      <td>totals_stats</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  namespace            tableName  isTemporary\n",
+              "0       nba             salaries        False\n",
+              "1       nba  allstar_games_stats        False\n",
+              "2       nba         totals_stats        False"
+            ]
           },
-          "execution_count": 27,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -921,17 +1820,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>58</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        58"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>58</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        58"
+            ]
           },
-          "execution_count": 28,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -950,20 +1880,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>count(1)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>54</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   count(1)\n0        54"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count(1)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>54</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   count(1)\n",
+              "0        54"
+            ]
           },
-          "execution_count": 29,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -985,19 +1947,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "DataFrame[status: string]"
+            "text/plain": [
+              "DataFrame[status: string]"
+            ]
           },
-          "execution_count": 30,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }

--- a/notebooks/nessie-iceberg-flink-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-flink-demo-nba.ipynb
@@ -1988,13 +1988,6 @@
       "source": [
         "table_env.from_path(\"main_catalog.nba.`salaries@main`\").select(lit(1).count).to_pandas()"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {

--- a/notebooks/nessie-iceberg-flink-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-flink-demo-nba.ipynb
@@ -20,23 +20,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "SLF4J: Class path contains multiple SLF4J bindings.\nSLF4J: Found binding in [jar:file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/log4j-slf4j-impl-2.17.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]\nSLF4J: Found binding in [jar:file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]\nSLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.\nSLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]\n"
+          "text": [
+            "SLF4J: Class path contains multiple SLF4J bindings.\n",
+            "SLF4J: Found binding in [jar:file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/log4j-slf4j-impl-2.17.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
+            "SLF4J: Found binding in [jar:file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
+            "SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.\n",
+            "SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n\n\nFlink running\n\n\n\n"
+          "text": [
+            "\n",
+            "\n",
+            "\n",
+            "Flink running\n",
+            "\n",
+            "\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -117,10 +130,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "create_ref_catalog(\"dev\")"
@@ -141,18 +152,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "  dev   2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[0m\n"
+          "text": [
+            "  dev   2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[0m\n"
+          ]
         }
       ],
       "source": [
@@ -182,20 +196,51 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stderr",
           "output_type": "stream",
-          "text": "WARNING: An illegal reflective access operation has occurred\nWARNING: Illegal reflective access by org.apache.hadoop.security.authentication.util.KerberosUtil (file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/hadoop-auth-2.10.1.jar) to method sun.security.krb5.Config.getInstance()\nWARNING: Please consider reporting this to the maintainers of org.apache.hadoop.security.authentication.util.KerberosUtil\nWARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\nWARNING: All illegal access operations will be denied in a future release\nlog4j:WARN No appenders could be found for logger (org.apache.htrace.core.Tracer).\nlog4j:WARN Please initialize the log4j system properly.\nlog4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.\n"
+          "text": [
+            "WARNING: An illegal reflective access operation has occurred\n",
+            "WARNING: Illegal reflective access by org.apache.hadoop.security.authentication.util.KerberosUtil (file:/srv/conda/envs/flink-demo/lib/python3.7/site-packages/pyflink/lib/hadoop-auth-2.10.1.jar) to method sun.security.krb5.Config.getInstance()\n",
+            "WARNING: Please consider reporting this to the maintainers of org.apache.hadoop.security.authentication.util.KerberosUtil\n",
+            "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
+            "WARNING: All illegal access operations will be denied in a future release\n",
+            "log4j:WARN No appenders could be found for logger (org.apache.htrace.core.Tracer).\n",
+            "log4j:WARN Please initialize the log4j system properly.\n",
+            "log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.\n"
+          ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,664 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,664 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,665 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:44:59,665 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n\n\n\nAdded 51 rows to the salaries table and 93 rows to the totals_stats table.\n\n\n\n"
+          "text": [
+            "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,464 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:58,465 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,663 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,664 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,664 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,665 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:44:59,665 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "\n",
+            "\n",
+            "\n",
+            "Added 51 rows to the salaries table and 93 rows to the totals_stats table.\n",
+            "\n",
+            "\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -299,18 +344,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:04,807 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,869 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,872 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,874 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,876 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,879 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,881 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:04,883 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n51\n2022-05-24 07:45:06,280 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,344 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,347 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,351 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,354 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,357 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,360 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:06,364 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n93\n"
+          "text": [
+            "2022-05-24 07:45:04,807 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,869 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,872 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,874 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,876 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,879 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,881 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:04,883 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "51\n",
+            "2022-05-24 07:45:06,280 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,344 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,347 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,351 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,354 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,357 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,360 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:06,364 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "93\n"
+          ]
         }
       ],
       "source": [
@@ -337,18 +400,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -371,15 +435,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.totals_stats\n\tnba.salaries\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.totals_stats\n",
+            "\tnba.salaries\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -399,15 +466,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[0m\n"
+          "text": [
+            "  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n",
+            "\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[0m\n"
+          ]
         }
       ],
       "source": [
@@ -427,15 +496,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -457,15 +526,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\u001b[33m* main  facfd43be1d062734ca0cda5ae900dde398180bf3f370a19627da8a2419589b0\n\u001b[0m  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n\n"
+          "text": [
+            "\u001b[33m* main  facfd43be1d062734ca0cda5ae900dde398180bf3f370a19627da8a2419589b0\n",
+            "\u001b[0m  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -474,18 +545,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -494,18 +569,34 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:10,661 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,724 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,725 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,727 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,729 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,730 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,732 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:10,733 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,239 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,304 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,307 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,312 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,316 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,319 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,322 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:12,326 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          "text": [
+            "2022-05-24 07:45:10,661 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,724 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,725 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,727 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,729 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,730 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,732 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:10,733 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,239 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,304 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,307 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,312 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,316 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,319 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,322 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:12,326 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          ]
         }
       ],
       "source": [
@@ -539,10 +630,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "create_ref_catalog(\"etl\")"
@@ -550,18 +639,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:13,368 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n"
+          "text": [
+            "2022-05-24 07:45:13,368 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n"
+          ]
         }
       ],
       "source": [
@@ -577,10 +667,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "# Rename the table `totals_stats` to `new_totals_stats`\n",
@@ -589,22 +677,844 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n2022-05-24 07:45:15,480 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,543 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,546 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,549 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,551 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,554 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,557 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:15,560 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          "text": [
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:14,227 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n",
+            "2022-05-24 07:45:15,480 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,543 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,546 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,549 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,551 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,554 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,557 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:15,560 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          ]
         },
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Season</th>\n      <th>Age</th>\n      <th>Team</th>\n      <th>ORB</th>\n      <th>TRB</th>\n      <th>AST</th>\n      <th>STL</th>\n      <th>BLK</th>\n      <th>TOV</th>\n      <th>PF</th>\n      <th>PTS</th>\n      <th>Player</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2004-05</td>\n      <td>26</td>\n      <td>LAL</td>\n      <td>3</td>\n      <td>6</td>\n      <td>7</td>\n      <td>3</td>\n      <td>1</td>\n      <td>4</td>\n      <td>5</td>\n      <td>16</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2005-06</td>\n      <td>27</td>\n      <td>LAL</td>\n      <td>0</td>\n      <td>7</td>\n      <td>8</td>\n      <td>3</td>\n      <td>0</td>\n      <td>3</td>\n      <td>5</td>\n      <td>8</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2006-07</td>\n      <td>28</td>\n      <td>LAL</td>\n      <td>1</td>\n      <td>5</td>\n      <td>6</td>\n      <td>6</td>\n      <td>0</td>\n      <td>4</td>\n      <td>1</td>\n      <td>31</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2007-08</td>\n      <td>29</td>\n      <td>LAL</td>\n      <td>0</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2008-09</td>\n      <td>30</td>\n      <td>LAL</td>\n      <td>1</td>\n      <td>4</td>\n      <td>4</td>\n      <td>4</td>\n      <td>0</td>\n      <td>1</td>\n      <td>0</td>\n      <td>27</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2009-10</td>\n      <td>31</td>\n      <td>LAL</td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2009-10</td>\n      <td>25</td>\n      <td>CLE</td>\n      <td>1</td>\n      <td>5</td>\n      <td>6</td>\n      <td>4</td>\n      <td>0</td>\n      <td>2</td>\n      <td>1</td>\n      <td>25</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2010-11</td>\n      <td>26</td>\n      <td>MIA</td>\n      <td>2</td>\n      <td>12</td>\n      <td>10</td>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>3</td>\n      <td>29</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2011-12</td>\n      <td>27</td>\n      <td>MIA</td>\n      <td>0</td>\n      <td>6</td>\n      <td>7</td>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>2</td>\n      <td>36</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2012-13</td>\n      <td>28</td>\n      <td>MIA</td>\n      <td>0</td>\n      <td>3</td>\n      <td>5</td>\n      <td>1</td>\n      <td>0</td>\n      <td>4</td>\n      <td>0</td>\n      <td>19</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2013-14</td>\n      <td>29</td>\n      <td>MIA</td>\n      <td>1</td>\n      <td>7</td>\n      <td>7</td>\n      <td>3</td>\n      <td>0</td>\n      <td>1</td>\n      <td>0</td>\n      <td>22</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>2014-15</td>\n      <td>30</td>\n      <td>CLE</td>\n      <td>1</td>\n      <td>5</td>\n      <td>7</td>\n      <td>2</td>\n      <td>0</td>\n      <td>4</td>\n      <td>1</td>\n      <td>30</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>2010-11</td>\n      <td>32</td>\n      <td>LAL</td>\n      <td>10</td>\n      <td>14</td>\n      <td>3</td>\n      <td>3</td>\n      <td>0</td>\n      <td>4</td>\n      <td>2</td>\n      <td>37</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>2011-12</td>\n      <td>33</td>\n      <td>LAL</td>\n      <td>0</td>\n      <td>1</td>\n      <td>1</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>2</td>\n      <td>27</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>2012-13</td>\n      <td>34</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>4</td>\n      <td>8</td>\n      <td>2</td>\n      <td>2</td>\n      <td>1</td>\n      <td>2</td>\n      <td>9</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>2013-14</td>\n      <td>35</td>\n      <td>LAL</td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>2014-15</td>\n      <td>36</td>\n      <td>LAL</td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>2015-16</td>\n      <td>37</td>\n      <td>LAL</td>\n      <td>1</td>\n      <td>6</td>\n      <td>7</td>\n      <td>1</td>\n      <td>0</td>\n      <td>1</td>\n      <td>1</td>\n      <td>10</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>1997-98</td>\n      <td>19</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>6</td>\n      <td>1</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>1</td>\n      <td>18</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>1999-00</td>\n      <td>21</td>\n      <td>LAL</td>\n      <td>1</td>\n      <td>1</td>\n      <td>3</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>3</td>\n      <td>15</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>2000-01</td>\n      <td>22</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>4</td>\n      <td>7</td>\n      <td>1</td>\n      <td>0</td>\n      <td>3</td>\n      <td>3</td>\n      <td>19</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>2001-02</td>\n      <td>23</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>5</td>\n      <td>5</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0</td>\n      <td>2</td>\n      <td>31</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>2002-03</td>\n      <td>24</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>7</td>\n      <td>6</td>\n      <td>3</td>\n      <td>2</td>\n      <td>5</td>\n      <td>5</td>\n      <td>22</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>2003-04</td>\n      <td>25</td>\n      <td>LAL</td>\n      <td>1</td>\n      <td>4</td>\n      <td>4</td>\n      <td>5</td>\n      <td>1</td>\n      <td>6</td>\n      <td>3</td>\n      <td>20</td>\n      <td>Kobe Bryant</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>Season</td>\n      <td>Age</td>\n      <td>Team</td>\n      <td>ORB</td>\n      <td>TRB</td>\n      <td>AST</td>\n      <td>STL</td>\n      <td>BLK</td>\n      <td>TOV</td>\n      <td>PF</td>\n      <td>PTS</td>\n      <td>Player</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>2004-05</td>\n      <td>20</td>\n      <td>CLE</td>\n      <td>1</td>\n      <td>8</td>\n      <td>6</td>\n      <td>2</td>\n      <td>0</td>\n      <td>3</td>\n      <td>0</td>\n      <td>13</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>2005-06</td>\n      <td>21</td>\n      <td>CLE</td>\n      <td>2</td>\n      <td>6</td>\n      <td>2</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>2</td>\n      <td>29</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>2006-07</td>\n      <td>22</td>\n      <td>CLE</td>\n      <td>0</td>\n      <td>6</td>\n      <td>6</td>\n      <td>1</td>\n      <td>0</td>\n      <td>4</td>\n      <td>0</td>\n      <td>28</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>2007-08</td>\n      <td>23</td>\n      <td>CLE</td>\n      <td>1</td>\n      <td>8</td>\n      <td>9</td>\n      <td>2</td>\n      <td>2</td>\n      <td>4</td>\n      <td>3</td>\n      <td>27</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>2008-09</td>\n      <td>24</td>\n      <td>CLE</td>\n      <td>0</td>\n      <td>5</td>\n      <td>3</td>\n      <td>0</td>\n      <td>0</td>\n      <td>3</td>\n      <td>0</td>\n      <td>20</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>30</th>\n      <td>1992-93</td>\n      <td>29</td>\n      <td>CHI</td>\n      <td>3</td>\n      <td>4</td>\n      <td>5</td>\n      <td>4</td>\n      <td>0</td>\n      <td>6</td>\n      <td>5</td>\n      <td>30</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>31</th>\n      <td>1995-96</td>\n      <td>32</td>\n      <td>CHI</td>\n      <td>1</td>\n      <td>4</td>\n      <td>1</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0</td>\n      <td>1</td>\n      <td>20</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>32</th>\n      <td>1996-97</td>\n      <td>33</td>\n      <td>CHI</td>\n      <td>3</td>\n      <td>11</td>\n      <td>11</td>\n      <td>2</td>\n      <td>0</td>\n      <td>3</td>\n      <td>4</td>\n      <td>14</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>33</th>\n      <td>1997-98</td>\n      <td>34</td>\n      <td>CHI</td>\n      <td>1</td>\n      <td>6</td>\n      <td>8</td>\n      <td>3</td>\n      <td>0</td>\n      <td>2</td>\n      <td>0</td>\n      <td>23</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>34</th>\n      <td>2001-02</td>\n      <td>38</td>\n      <td>WAS</td>\n      <td>0</td>\n      <td>4</td>\n      <td>3</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>1</td>\n      <td>8</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>35</th>\n      <td>2002-03</td>\n      <td>39</td>\n      <td>WAS</td>\n      <td>2</td>\n      <td>5</td>\n      <td>2</td>\n      <td>2</td>\n      <td>0</td>\n      <td>2</td>\n      <td>3</td>\n      <td>20</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>36</th>\n      <td>2015-16</td>\n      <td>31</td>\n      <td>CLE</td>\n      <td>0</td>\n      <td>4</td>\n      <td>7</td>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>0</td>\n      <td>13</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>37</th>\n      <td>2016-17</td>\n      <td>32</td>\n      <td>CLE</td>\n      <td>0</td>\n      <td>3</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>2</td>\n      <td>23</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>38</th>\n      <td>2017-18</td>\n      <td>33</td>\n      <td>CLE</td>\n      <td>0</td>\n      <td>10</td>\n      <td>8</td>\n      <td>1</td>\n      <td>0</td>\n      <td>5</td>\n      <td>2</td>\n      <td>29</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>39</th>\n      <td>2018-19</td>\n      <td>34</td>\n      <td>LAL</td>\n      <td>2</td>\n      <td>8</td>\n      <td>4</td>\n      <td>0</td>\n      <td>2</td>\n      <td>1</td>\n      <td>1</td>\n      <td>19</td>\n      <td>Lebron James</td>\n    </tr>\n    <tr>\n      <th>40</th>\n      <td>1984-85</td>\n      <td>21</td>\n      <td>CHI</td>\n      <td>3</td>\n      <td>6</td>\n      <td>2</td>\n      <td>3</td>\n      <td>1</td>\n      <td>1</td>\n      <td>4</td>\n      <td>7</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>41</th>\n      <td>1985-86</td>\n      <td>22</td>\n      <td>CHI</td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td></td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>42</th>\n      <td>1986-87</td>\n      <td>23</td>\n      <td>CHI</td>\n      <td>0</td>\n      <td>0</td>\n      <td>4</td>\n      <td>2</td>\n      <td>0</td>\n      <td>5</td>\n      <td>2</td>\n      <td>11</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>43</th>\n      <td>1987-88</td>\n      <td>24</td>\n      <td>CHI</td>\n      <td>3</td>\n      <td>8</td>\n      <td>3</td>\n      <td>4</td>\n      <td>4</td>\n      <td>2</td>\n      <td>5</td>\n      <td>40</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>44</th>\n      <td>1988-89</td>\n      <td>25</td>\n      <td>CHI</td>\n      <td>1</td>\n      <td>2</td>\n      <td>3</td>\n      <td>5</td>\n      <td>0</td>\n      <td>4</td>\n      <td>1</td>\n      <td>28</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>45</th>\n      <td>1989-90</td>\n      <td>26</td>\n      <td>CHI</td>\n      <td>1</td>\n      <td>5</td>\n      <td>2</td>\n      <td>5</td>\n      <td>1</td>\n      <td>5</td>\n      <td>1</td>\n      <td>17</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>46</th>\n      <td>1990-91</td>\n      <td>27</td>\n      <td>CHI</td>\n      <td>3</td>\n      <td>5</td>\n      <td>5</td>\n      <td>2</td>\n      <td>0</td>\n      <td>10</td>\n      <td>2</td>\n      <td>26</td>\n      <td>Michael Jordan</td>\n    </tr>\n    <tr>\n      <th>47</th>\n      <td>1991-92</td>\n      <td>28</td>\n      <td>CHI</td>\n      <td>1</td>\n      <td>1</td>\n      <td>5</td>\n      <td>2</td>\n      <td>0</td>\n      <td>1</td>\n      <td>2</td>\n      <td>18</td>\n      <td>Michael Jordan</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "     Season  Age  Team  ORB  TRB  AST  STL  BLK  TOV  PF  PTS          Player\n0   2004-05   26   LAL    3    6    7    3    1    4   5   16     Kobe Bryant\n1   2005-06   27   LAL    0    7    8    3    0    3   5    8     Kobe Bryant\n2   2006-07   28   LAL    1    5    6    6    0    4   1   31     Kobe Bryant\n3   2007-08   29   LAL    0    1    0    0    0    0   0    0     Kobe Bryant\n4   2008-09   30   LAL    1    4    4    4    0    1   0   27     Kobe Bryant\n5   2009-10   31   LAL                                            Kobe Bryant\n6   2009-10   25   CLE    1    5    6    4    0    2   1   25    Lebron James\n7   2010-11   26   MIA    2   12   10    0    0    4   3   29    Lebron James\n8   2011-12   27   MIA    0    6    7    0    0    4   2   36    Lebron James\n9   2012-13   28   MIA    0    3    5    1    0    4   0   19    Lebron James\n10  2013-14   29   MIA    1    7    7    3    0    1   0   22    Lebron James\n11  2014-15   30   CLE    1    5    7    2    0    4   1   30    Lebron James\n12  2010-11   32   LAL   10   14    3    3    0    4   2   37     Kobe Bryant\n13  2011-12   33   LAL    0    1    1    2    0    1   2   27     Kobe Bryant\n14  2012-13   34   LAL    2    4    8    2    2    1   2    9     Kobe Bryant\n15  2013-14   35   LAL                                            Kobe Bryant\n16  2014-15   36   LAL                                            Kobe Bryant\n17  2015-16   37   LAL    1    6    7    1    0    1   1   10     Kobe Bryant\n18  1997-98   19   LAL    2    6    1    2    0    1   1   18     Kobe Bryant\n19  1999-00   21   LAL    1    1    3    2    0    1   3   15     Kobe Bryant\n20  2000-01   22   LAL    2    4    7    1    0    3   3   19     Kobe Bryant\n21  2001-02   23   LAL    2    5    5    1    0    0   2   31     Kobe Bryant\n22  2002-03   24   LAL    2    7    6    3    2    5   5   22     Kobe Bryant\n23  2003-04   25   LAL    1    4    4    5    1    6   3   20     Kobe Bryant\n24   Season  Age  Team  ORB  TRB  AST  STL  BLK  TOV  PF  PTS          Player\n25  2004-05   20   CLE    1    8    6    2    0    3   0   13    Lebron James\n26  2005-06   21   CLE    2    6    2    2    0    1   2   29    Lebron James\n27  2006-07   22   CLE    0    6    6    1    0    4   0   28    Lebron James\n28  2007-08   23   CLE    1    8    9    2    2    4   3   27    Lebron James\n29  2008-09   24   CLE    0    5    3    0    0    3   0   20    Lebron James\n30  1992-93   29   CHI    3    4    5    4    0    6   5   30  Michael Jordan\n31  1995-96   32   CHI    1    4    1    1    0    0   1   20  Michael Jordan\n32  1996-97   33   CHI    3   11   11    2    0    3   4   14  Michael Jordan\n33  1997-98   34   CHI    1    6    8    3    0    2   0   23  Michael Jordan\n34  2001-02   38   WAS    0    4    3    2    0    1   1    8  Michael Jordan\n35  2002-03   39   WAS    2    5    2    2    0    2   3   20  Michael Jordan\n36  2015-16   31   CLE    0    4    7    0    0    4   0   13    Lebron James\n37  2016-17   32   CLE    0    3    1    0    0    4   2   23    Lebron James\n38  2017-18   33   CLE    0   10    8    1    0    5   2   29    Lebron James\n39  2018-19   34   LAL    2    8    4    0    2    1   1   19    Lebron James\n40  1984-85   21   CHI    3    6    2    3    1    1   4    7  Michael Jordan\n41  1985-86   22   CHI                                         Michael Jordan\n42  1986-87   23   CHI    0    0    4    2    0    5   2   11  Michael Jordan\n43  1987-88   24   CHI    3    8    3    4    4    2   5   40  Michael Jordan\n44  1988-89   25   CHI    1    2    3    5    0    4   1   28  Michael Jordan\n45  1989-90   26   CHI    1    5    2    5    1    5   1   17  Michael Jordan\n46  1990-91   27   CHI    3    5    5    2    0   10   2   26  Michael Jordan\n47  1991-92   28   CHI    1    1    5    2    0    1   2   18  Michael Jordan"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Season</th>\n",
+              "      <th>Age</th>\n",
+              "      <th>Team</th>\n",
+              "      <th>ORB</th>\n",
+              "      <th>TRB</th>\n",
+              "      <th>AST</th>\n",
+              "      <th>STL</th>\n",
+              "      <th>BLK</th>\n",
+              "      <th>TOV</th>\n",
+              "      <th>PF</th>\n",
+              "      <th>PTS</th>\n",
+              "      <th>Player</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>2004-05</td>\n",
+              "      <td>26</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>3</td>\n",
+              "      <td>6</td>\n",
+              "      <td>7</td>\n",
+              "      <td>3</td>\n",
+              "      <td>1</td>\n",
+              "      <td>4</td>\n",
+              "      <td>5</td>\n",
+              "      <td>16</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>2005-06</td>\n",
+              "      <td>27</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>0</td>\n",
+              "      <td>7</td>\n",
+              "      <td>8</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>5</td>\n",
+              "      <td>8</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>2006-07</td>\n",
+              "      <td>28</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>6</td>\n",
+              "      <td>6</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>1</td>\n",
+              "      <td>31</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>2007-08</td>\n",
+              "      <td>29</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>2008-09</td>\n",
+              "      <td>30</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>1</td>\n",
+              "      <td>4</td>\n",
+              "      <td>4</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>27</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>2009-10</td>\n",
+              "      <td>31</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>2009-10</td>\n",
+              "      <td>25</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>6</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2</td>\n",
+              "      <td>1</td>\n",
+              "      <td>25</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>2010-11</td>\n",
+              "      <td>26</td>\n",
+              "      <td>MIA</td>\n",
+              "      <td>2</td>\n",
+              "      <td>12</td>\n",
+              "      <td>10</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>3</td>\n",
+              "      <td>29</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>2011-12</td>\n",
+              "      <td>27</td>\n",
+              "      <td>MIA</td>\n",
+              "      <td>0</td>\n",
+              "      <td>6</td>\n",
+              "      <td>7</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>2</td>\n",
+              "      <td>36</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>2012-13</td>\n",
+              "      <td>28</td>\n",
+              "      <td>MIA</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>5</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>19</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>2013-14</td>\n",
+              "      <td>29</td>\n",
+              "      <td>MIA</td>\n",
+              "      <td>1</td>\n",
+              "      <td>7</td>\n",
+              "      <td>7</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>22</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>2014-15</td>\n",
+              "      <td>30</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>7</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>1</td>\n",
+              "      <td>30</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12</th>\n",
+              "      <td>2010-11</td>\n",
+              "      <td>32</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>10</td>\n",
+              "      <td>14</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>2</td>\n",
+              "      <td>37</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13</th>\n",
+              "      <td>2011-12</td>\n",
+              "      <td>33</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>27</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>14</th>\n",
+              "      <td>2012-13</td>\n",
+              "      <td>34</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>4</td>\n",
+              "      <td>8</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>9</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>15</th>\n",
+              "      <td>2013-14</td>\n",
+              "      <td>35</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>16</th>\n",
+              "      <td>2014-15</td>\n",
+              "      <td>36</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>17</th>\n",
+              "      <td>2015-16</td>\n",
+              "      <td>37</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>1</td>\n",
+              "      <td>6</td>\n",
+              "      <td>7</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>10</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>18</th>\n",
+              "      <td>1997-98</td>\n",
+              "      <td>19</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>6</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>18</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>19</th>\n",
+              "      <td>1999-00</td>\n",
+              "      <td>21</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>3</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>3</td>\n",
+              "      <td>15</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>20</th>\n",
+              "      <td>2000-01</td>\n",
+              "      <td>22</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>4</td>\n",
+              "      <td>7</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>19</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>21</th>\n",
+              "      <td>2001-02</td>\n",
+              "      <td>23</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>5</td>\n",
+              "      <td>5</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2</td>\n",
+              "      <td>31</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>22</th>\n",
+              "      <td>2002-03</td>\n",
+              "      <td>24</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>7</td>\n",
+              "      <td>6</td>\n",
+              "      <td>3</td>\n",
+              "      <td>2</td>\n",
+              "      <td>5</td>\n",
+              "      <td>5</td>\n",
+              "      <td>22</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>23</th>\n",
+              "      <td>2003-04</td>\n",
+              "      <td>25</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>1</td>\n",
+              "      <td>4</td>\n",
+              "      <td>4</td>\n",
+              "      <td>5</td>\n",
+              "      <td>1</td>\n",
+              "      <td>6</td>\n",
+              "      <td>3</td>\n",
+              "      <td>20</td>\n",
+              "      <td>Kobe Bryant</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>24</th>\n",
+              "      <td>Season</td>\n",
+              "      <td>Age</td>\n",
+              "      <td>Team</td>\n",
+              "      <td>ORB</td>\n",
+              "      <td>TRB</td>\n",
+              "      <td>AST</td>\n",
+              "      <td>STL</td>\n",
+              "      <td>BLK</td>\n",
+              "      <td>TOV</td>\n",
+              "      <td>PF</td>\n",
+              "      <td>PTS</td>\n",
+              "      <td>Player</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25</th>\n",
+              "      <td>2004-05</td>\n",
+              "      <td>20</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>1</td>\n",
+              "      <td>8</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>13</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>2005-06</td>\n",
+              "      <td>21</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>2</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>29</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>27</th>\n",
+              "      <td>2006-07</td>\n",
+              "      <td>22</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>0</td>\n",
+              "      <td>6</td>\n",
+              "      <td>6</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>28</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>28</th>\n",
+              "      <td>2007-08</td>\n",
+              "      <td>23</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>1</td>\n",
+              "      <td>8</td>\n",
+              "      <td>9</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2</td>\n",
+              "      <td>4</td>\n",
+              "      <td>3</td>\n",
+              "      <td>27</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>29</th>\n",
+              "      <td>2008-09</td>\n",
+              "      <td>24</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>0</td>\n",
+              "      <td>5</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>20</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>30</th>\n",
+              "      <td>1992-93</td>\n",
+              "      <td>29</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>3</td>\n",
+              "      <td>4</td>\n",
+              "      <td>5</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>6</td>\n",
+              "      <td>5</td>\n",
+              "      <td>30</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>31</th>\n",
+              "      <td>1995-96</td>\n",
+              "      <td>32</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>1</td>\n",
+              "      <td>4</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>20</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>32</th>\n",
+              "      <td>1996-97</td>\n",
+              "      <td>33</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>3</td>\n",
+              "      <td>11</td>\n",
+              "      <td>11</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>4</td>\n",
+              "      <td>14</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>33</th>\n",
+              "      <td>1997-98</td>\n",
+              "      <td>34</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>1</td>\n",
+              "      <td>6</td>\n",
+              "      <td>8</td>\n",
+              "      <td>3</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>23</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>34</th>\n",
+              "      <td>2001-02</td>\n",
+              "      <td>38</td>\n",
+              "      <td>WAS</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>3</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>8</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>35</th>\n",
+              "      <td>2002-03</td>\n",
+              "      <td>39</td>\n",
+              "      <td>WAS</td>\n",
+              "      <td>2</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2</td>\n",
+              "      <td>3</td>\n",
+              "      <td>20</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>36</th>\n",
+              "      <td>2015-16</td>\n",
+              "      <td>31</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>7</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>13</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>37</th>\n",
+              "      <td>2016-17</td>\n",
+              "      <td>32</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>2</td>\n",
+              "      <td>23</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>38</th>\n",
+              "      <td>2017-18</td>\n",
+              "      <td>33</td>\n",
+              "      <td>CLE</td>\n",
+              "      <td>0</td>\n",
+              "      <td>10</td>\n",
+              "      <td>8</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>29</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>39</th>\n",
+              "      <td>2018-19</td>\n",
+              "      <td>34</td>\n",
+              "      <td>LAL</td>\n",
+              "      <td>2</td>\n",
+              "      <td>8</td>\n",
+              "      <td>4</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>19</td>\n",
+              "      <td>Lebron James</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>40</th>\n",
+              "      <td>1984-85</td>\n",
+              "      <td>21</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>3</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2</td>\n",
+              "      <td>3</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>4</td>\n",
+              "      <td>7</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41</th>\n",
+              "      <td>1985-86</td>\n",
+              "      <td>22</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td></td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>42</th>\n",
+              "      <td>1986-87</td>\n",
+              "      <td>23</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>11</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>43</th>\n",
+              "      <td>1987-88</td>\n",
+              "      <td>24</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>3</td>\n",
+              "      <td>8</td>\n",
+              "      <td>3</td>\n",
+              "      <td>4</td>\n",
+              "      <td>4</td>\n",
+              "      <td>2</td>\n",
+              "      <td>5</td>\n",
+              "      <td>40</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>44</th>\n",
+              "      <td>1988-89</td>\n",
+              "      <td>25</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>3</td>\n",
+              "      <td>5</td>\n",
+              "      <td>0</td>\n",
+              "      <td>4</td>\n",
+              "      <td>1</td>\n",
+              "      <td>28</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>45</th>\n",
+              "      <td>1989-90</td>\n",
+              "      <td>26</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>5</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>1</td>\n",
+              "      <td>17</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>46</th>\n",
+              "      <td>1990-91</td>\n",
+              "      <td>27</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>3</td>\n",
+              "      <td>5</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>10</td>\n",
+              "      <td>2</td>\n",
+              "      <td>26</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>47</th>\n",
+              "      <td>1991-92</td>\n",
+              "      <td>28</td>\n",
+              "      <td>CHI</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>18</td>\n",
+              "      <td>Michael Jordan</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "     Season  Age  Team  ORB  TRB  AST  STL  BLK  TOV  PF  PTS          Player\n",
+              "0   2004-05   26   LAL    3    6    7    3    1    4   5   16     Kobe Bryant\n",
+              "1   2005-06   27   LAL    0    7    8    3    0    3   5    8     Kobe Bryant\n",
+              "2   2006-07   28   LAL    1    5    6    6    0    4   1   31     Kobe Bryant\n",
+              "3   2007-08   29   LAL    0    1    0    0    0    0   0    0     Kobe Bryant\n",
+              "4   2008-09   30   LAL    1    4    4    4    0    1   0   27     Kobe Bryant\n",
+              "5   2009-10   31   LAL                                            Kobe Bryant\n",
+              "6   2009-10   25   CLE    1    5    6    4    0    2   1   25    Lebron James\n",
+              "7   2010-11   26   MIA    2   12   10    0    0    4   3   29    Lebron James\n",
+              "8   2011-12   27   MIA    0    6    7    0    0    4   2   36    Lebron James\n",
+              "9   2012-13   28   MIA    0    3    5    1    0    4   0   19    Lebron James\n",
+              "10  2013-14   29   MIA    1    7    7    3    0    1   0   22    Lebron James\n",
+              "11  2014-15   30   CLE    1    5    7    2    0    4   1   30    Lebron James\n",
+              "12  2010-11   32   LAL   10   14    3    3    0    4   2   37     Kobe Bryant\n",
+              "13  2011-12   33   LAL    0    1    1    2    0    1   2   27     Kobe Bryant\n",
+              "14  2012-13   34   LAL    2    4    8    2    2    1   2    9     Kobe Bryant\n",
+              "15  2013-14   35   LAL                                            Kobe Bryant\n",
+              "16  2014-15   36   LAL                                            Kobe Bryant\n",
+              "17  2015-16   37   LAL    1    6    7    1    0    1   1   10     Kobe Bryant\n",
+              "18  1997-98   19   LAL    2    6    1    2    0    1   1   18     Kobe Bryant\n",
+              "19  1999-00   21   LAL    1    1    3    2    0    1   3   15     Kobe Bryant\n",
+              "20  2000-01   22   LAL    2    4    7    1    0    3   3   19     Kobe Bryant\n",
+              "21  2001-02   23   LAL    2    5    5    1    0    0   2   31     Kobe Bryant\n",
+              "22  2002-03   24   LAL    2    7    6    3    2    5   5   22     Kobe Bryant\n",
+              "23  2003-04   25   LAL    1    4    4    5    1    6   3   20     Kobe Bryant\n",
+              "24   Season  Age  Team  ORB  TRB  AST  STL  BLK  TOV  PF  PTS          Player\n",
+              "25  2004-05   20   CLE    1    8    6    2    0    3   0   13    Lebron James\n",
+              "26  2005-06   21   CLE    2    6    2    2    0    1   2   29    Lebron James\n",
+              "27  2006-07   22   CLE    0    6    6    1    0    4   0   28    Lebron James\n",
+              "28  2007-08   23   CLE    1    8    9    2    2    4   3   27    Lebron James\n",
+              "29  2008-09   24   CLE    0    5    3    0    0    3   0   20    Lebron James\n",
+              "30  1992-93   29   CHI    3    4    5    4    0    6   5   30  Michael Jordan\n",
+              "31  1995-96   32   CHI    1    4    1    1    0    0   1   20  Michael Jordan\n",
+              "32  1996-97   33   CHI    3   11   11    2    0    3   4   14  Michael Jordan\n",
+              "33  1997-98   34   CHI    1    6    8    3    0    2   0   23  Michael Jordan\n",
+              "34  2001-02   38   WAS    0    4    3    2    0    1   1    8  Michael Jordan\n",
+              "35  2002-03   39   WAS    2    5    2    2    0    2   3   20  Michael Jordan\n",
+              "36  2015-16   31   CLE    0    4    7    0    0    4   0   13    Lebron James\n",
+              "37  2016-17   32   CLE    0    3    1    0    0    4   2   23    Lebron James\n",
+              "38  2017-18   33   CLE    0   10    8    1    0    5   2   29    Lebron James\n",
+              "39  2018-19   34   LAL    2    8    4    0    2    1   1   19    Lebron James\n",
+              "40  1984-85   21   CHI    3    6    2    3    1    1   4    7  Michael Jordan\n",
+              "41  1985-86   22   CHI                                         Michael Jordan\n",
+              "42  1986-87   23   CHI    0    0    4    2    0    5   2   11  Michael Jordan\n",
+              "43  1987-88   24   CHI    3    8    3    4    4    2   5   40  Michael Jordan\n",
+              "44  1988-89   25   CHI    1    2    3    5    0    4   1   28  Michael Jordan\n",
+              "45  1989-90   26   CHI    1    5    2    5    1    5   1   17  Michael Jordan\n",
+              "46  1990-91   27   CHI    3    5    5    2    0   10   2   26  Michael Jordan\n",
+              "47  1991-92   28   CHI    1    1    5    2    0    1   2   18  Michael Jordan"
+            ]
           },
-          "execution_count": 16,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -668,15 +1578,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -686,15 +1599,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.allstar_games_stats\n\tnba.new_totals_stats\n\tnba.salaries\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.allstar_games_stats\n",
+            "\tnba.new_totals_stats\n",
+            "\tnba.salaries\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -711,22 +1628,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -749,18 +1666,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.new_totals_stats\n\tnba.allstar_games_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.new_totals_stats\n",
+            "\tnba.allstar_games_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -769,18 +1691,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\u001b[33m* main  720543fa3a9579d0bfee11e07f383d86468eb4d73dc207e5bd6ef7f76b000930\n\u001b[0m  etl   c962d80b04ee619a6a0670cb5f664d948c86f6ebf66435027c5abe761e920c9e\n  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n\n"
+          "text": [
+            "\u001b[33m* main  720543fa3a9579d0bfee11e07f383d86468eb4d73dc207e5bd6ef7f76b000930\n",
+            "\u001b[0m  etl   c962d80b04ee619a6a0670cb5f664d948c86f6ebf66435027c5abe761e920c9e\n",
+            "  dev   f48b93594ddead3a7616a271d657f0fff97cd0c4c04d4a579fa165aa96a69908\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -789,18 +1715,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:19,196 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,257 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,260 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,263 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,265 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,268 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,270 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n2022-05-24 07:45:19,273 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          "text": [
+            "2022-05-24 07:45:19,196 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,257 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,260 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,263 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,265 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,268 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,270 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n",
+            "2022-05-24 07:45:19,273 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new decompressor [.gz]\n"
+          ]
         }
       ],
       "source": [
@@ -829,10 +1763,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "create_ref_catalog(\"experiment\")"
@@ -840,16 +1772,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/plain": "<pyflink.table.table_result.TableResult at 0x7f0413977b90>"
+            "text/plain": [
+              "<pyflink.table.table_result.TableResult at 0x7f0413977b90>"
+            ]
           },
-          "execution_count": 24,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -861,15 +1793,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "2022-05-24 07:45:20,258 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n"
+          "text": [
+            "2022-05-24 07:45:20,258 INFO  org.apache.hadoop.io.compress.CodecPool                      [] - Got brand-new compressor [.gz]\n"
+          ]
         }
       ],
       "source": [
@@ -885,15 +1817,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.allstar_games_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.allstar_games_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -903,22 +1838,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.new_totals_stats\n\tnba.allstar_games_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.new_totals_stats\n",
+            "\tnba.allstar_games_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -936,17 +1875,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>EXPR$0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>59</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   EXPR$0\n0      59"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>EXPR$0</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>59</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   EXPR$0\n",
+              "0      59"
+            ]
           },
-          "execution_count": 28,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -965,20 +1935,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>EXPR$0</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>55</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
-            "text/plain": "   EXPR$0\n0      55"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>EXPR$0</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>55</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   EXPR$0\n",
+              "0      55"
+            ]
           },
-          "execution_count": 29,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }

--- a/notebooks/nessie-iceberg-hive-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-hive-demo-nba.ipynb
@@ -22,19 +22,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
         },
-        "tags": [],
-        "trusted": true
+        "tags": []
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n\nHive running\n\n\n\n"
+          "text": [
+            "\n",
+            "\n",
+            "Hive running\n",
+            "\n",
+            "\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -113,10 +119,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "current_ref = create_ref_catalog(\"dev\")"
@@ -137,18 +141,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "  dev   2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[0m\n"
+          "text": [
+            "  dev   2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[0m\n"
+          ]
         }
       ],
       "source": [
@@ -178,15 +185,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCreated schema nba\n\n\nCreating tables nba.salaries and nba.totals_stats....\n\n\nCreated and inserted data into table nba.salaries from dataset salaries\n\n\nCreated and inserted data into table nba.totals_stats from dataset totals_stats\n\n"
+          "text": [
+            "\n",
+            "Created schema nba\n",
+            "\n",
+            "\n",
+            "Creating tables nba.salaries and nba.totals_stats....\n",
+            "\n",
+            "\n",
+            "Created and inserted data into table nba.salaries from dataset salaries\n",
+            "\n",
+            "\n",
+            "Created and inserted data into table nba.totals_stats from dataset totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -270,19 +288,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
         },
-        "tags": [],
-        "trusted": true
+        "tags": []
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCounting rows in nba.salaries\n\n51\n\nCounting rows in nba.totals_stats\n\n93\n"
+          "text": [
+            "\n",
+            "Counting rows in nba.salaries\n",
+            "\n",
+            "51\n",
+            "\n",
+            "Counting rows in nba.totals_stats\n",
+            "\n",
+            "93\n"
+          ]
         }
       ],
       "source": [
@@ -323,18 +349,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -357,15 +384,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.totals_stats\n\tnba.salaries\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.totals_stats\n",
+            "\tnba.salaries\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -385,15 +415,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n\u001b[0m\n"
+          "text": [
+            "  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n",
+            "\u001b[33m* main  2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\n",
+            "\u001b[0m\n"
+          ]
         }
       ],
       "source": [
@@ -413,15 +445,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -443,15 +475,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\u001b[33m* main  330f993ac08aceb2252702611f6bf1a92f49ac2e3fc709b250a017ba4a9cded6\n\u001b[0m  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n\n"
+          "text": [
+            "\u001b[33m* main  330f993ac08aceb2252702611f6bf1a92f49ac2e3fc709b250a017ba4a9cded6\n",
+            "\u001b[0m  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -460,18 +494,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -480,18 +518,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCounting rows in nba.salaries\n\n51\n\nCounting rows in nba.totals_stats\n\n93\n"
+          "text": [
+            "\n",
+            "Counting rows in nba.salaries\n",
+            "\n",
+            "51\n",
+            "\n",
+            "Counting rows in nba.totals_stats\n",
+            "\n",
+            "93\n"
+          ]
         }
       ],
       "source": [
@@ -541,10 +587,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "current_ref = create_ref_catalog(\"etl\")"
@@ -552,12 +596,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [],
       "source": [
@@ -573,15 +616,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCreating table nba.allstar_games_stats\n\n\nCreated and inserted data into table nba.allstar_table_temp from dataset allstar_games_stats\n\n\nCounting rows in nba.allstar_games_stats\n\n48\n"
+          "text": [
+            "\n",
+            "Creating table nba.allstar_games_stats\n",
+            "\n",
+            "\n",
+            "Created and inserted data into table nba.allstar_table_temp from dataset allstar_games_stats\n",
+            "\n",
+            "\n",
+            "Counting rows in nba.allstar_games_stats\n",
+            "\n",
+            "48\n"
+          ]
         }
       ],
       "source": [
@@ -634,15 +686,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -652,15 +707,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.allstar_games_stats\n\tnba.salaries\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.allstar_games_stats\n",
+            "\tnba.salaries\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -677,22 +736,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n"
+          "text": [
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -715,18 +774,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.allstar_games_stats\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.allstar_games_stats\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -735,18 +799,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\u001b[33m* main  11ed5b46713231a5fb85f31083d47dbf6bfa1df5839bebbac08301cda8afe22f\n\u001b[0m  etl   a3e06ba7595dfdb8bc67b0d6825587d2858cfe2b013bf1b95c5a1471578c4af3\n  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n\n"
+          "text": [
+            "\u001b[33m* main  11ed5b46713231a5fb85f31083d47dbf6bfa1df5839bebbac08301cda8afe22f\n",
+            "\u001b[0m  etl   a3e06ba7595dfdb8bc67b0d6825587d2858cfe2b013bf1b95c5a1471578c4af3\n",
+            "  dev   d1ea40ccb14fd8365828bf740d73e8ed9d04ce5d9739020d00d7ffa5937cf9d3\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -755,18 +823,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCounting rows in nba.allstar_games_stats\n\n48\n"
+          "text": [
+            "\n",
+            "Counting rows in nba.allstar_games_stats\n",
+            "\n",
+            "48\n"
+          ]
         }
       ],
       "source": [
@@ -801,10 +873,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "current_ref = create_ref_catalog(\"experiment\")"
@@ -812,10 +882,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "# Drop the `totals_stats` table on the `experiment` branch\n",
@@ -824,10 +892,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "# add some salaries for Dirk Nowitzki\n",
@@ -842,15 +908,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.allstar_games_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.allstar_games_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -860,22 +929,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": null,
       "metadata": {
-        "collapsed": false,
         "jupyter": {
           "outputs_hidden": false
         },
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "ICEBERG_TABLE:\n\tnba.salaries\n\tnba.allstar_games_stats\n\tnba.totals_stats\n\n"
+          "text": [
+            "ICEBERG_TABLE:\n",
+            "\tnba.salaries\n",
+            "\tnba.allstar_games_stats\n",
+            "\tnba.totals_stats\n",
+            "\n"
+          ]
         }
       ],
       "source": [
@@ -892,15 +965,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCounting rows in nba.salaries\n\n59\n"
+          "text": [
+            "\n",
+            "Counting rows in nba.salaries\n",
+            "\n",
+            "59\n"
+          ]
         }
       ],
       "source": [
@@ -921,18 +997,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": null,
       "metadata": {
         "pycharm": {
           "name": "#%%\n"
-        },
-        "trusted": true
+        }
       },
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\nCounting rows in nba.salaries\n\n56\n"
+          "text": [
+            "\n",
+            "Counting rows in nba.salaries\n",
+            "\n",
+            "56\n"
+          ]
         }
       ],
       "source": [
@@ -960,15 +1040,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
-      "metadata": {
-        "trusted": true
-      },
+      "execution_count": null,
+      "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": "\n\n\n"
+          "text": [
+            "\n",
+            "\n",
+            "\n"
+          ]
         }
       ],
       "source": [

--- a/notebooks/nessie-iceberg-hive-demo-nba.ipynb
+++ b/notebooks/nessie-iceberg-hive-demo-nba.ipynb
@@ -1058,13 +1058,6 @@
         "!nessie branch --delete etl\n",
         "!nessie branch --delete experiment"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {

--- a/notebooks/tox.ini
+++ b/notebooks/tox.ini
@@ -31,6 +31,8 @@ commands =
     python -m format_notebooks
     # this formats python code inside the notebooks
     bash -euo pipefail -c 'ls -1 *.ipynb | xargs --verbose black --target-version py37 --line-length 120 --ipynb'
+    # this formats cell output from single string to list of strings and removes execution metadata
+    bash -euo pipefail -c 'ls -1 *.ipynb | xargs --verbose nbstripout --keep-output'
     python -m format_notebooks
 
 [testenv:lint]

--- a/notebooks/tox.ini
+++ b/notebooks/tox.ini
@@ -32,7 +32,7 @@ commands =
     # this formats python code inside the notebooks
     bash -euo pipefail -c 'ls -1 *.ipynb | xargs --verbose black --target-version py37 --line-length 120 --ipynb'
     # this formats cell output from single string to list of strings and removes execution metadata
-    bash -euo pipefail -c 'ls -1 *.ipynb | xargs --verbose nbstripout --keep-output'
+    bash -euo pipefail -c 'ls -1 *.ipynb | xargs --verbose nbstripout --keep-output --strip-empty-cells'
     python -m format_notebooks
 
 [testenv:lint]


### PR DESCRIPTION
This strips the execution metadata from the notebooks while keeping the output.
As a nice bonus the output string gets formatted as a list of strings for improve diffs when we update demos next time.